### PR TITLE
KK-154 | Send GraphQL errors to sentry

### DIFF
--- a/children/schema.py
+++ b/children/schema.py
@@ -80,10 +80,11 @@ class ChildInput(graphene.InputObjectType):
 
 
 def validate_child_data(child_data):
-    try:
-        postal_code_validator(child_data["postal_code"])
-    except ValidationError as e:
-        raise GraphQLError(e.message)
+    if "postal_code" in child_data:
+        try:
+            postal_code_validator(child_data["postal_code"])
+        except ValidationError as e:
+            raise GraphQLError(e.message)
     return child_data
 
 

--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -231,3 +231,16 @@ snapshots["test_submit_children_and_guardian 1"] = {
         }
     }
 }
+
+snapshots["test_update_child_mutation_should_have_no_required_fields 1"] = {
+    "data": {
+        "updateChild": {
+            "child": {
+                "birthdate": "2019-09-08",
+                "firstName": "John",
+                "lastName": "Terrell",
+                "postalCode": "77671",
+            }
+        }
+    }
+}

--- a/children/tests/test_api.py
+++ b/children/tests/test_api.py
@@ -377,6 +377,17 @@ def test_update_child_mutation(snapshot, user_api_client):
     assert_relationship_matches_data(relationship, variables["input"]["relationship"])
 
 
+def test_update_child_mutation_should_have_no_required_fields(
+    snapshot, user_api_client
+):
+    child = ChildWithGuardianFactory(relationship__guardian__user=user_api_client.user)
+    variables = {"input": {"id": to_global_id("ChildNode", child.id)}}
+
+    executed = user_api_client.execute(UPDATE_CHILD_MUTATION, variables=variables)
+
+    snapshot.assert_match(executed)
+
+
 def test_update_child_mutation_wrong_user(snapshot, user_api_client):
     child = ChildWithGuardianFactory()
     variables = deepcopy(UPDATE_CHILD_VARIABLES)

--- a/kukkuu/exceptions.py
+++ b/kukkuu/exceptions.py
@@ -1,0 +1,5 @@
+from graphql import GraphQLError
+
+
+class KukkuuGraphQLError(GraphQLError):
+    """GraphQLError that is not sent to Sentry."""

--- a/kukkuu/urls.py
+++ b/kukkuu/urls.py
@@ -1,14 +1,14 @@
 from django.http import HttpResponse
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
-from graphene_django.views import GraphQLView
 from helusers.admin_site import admin
 
 from kukkuu import settings
+from kukkuu.views import SentryGraphQLView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("graphql", csrf_exempt(GraphQLView.as_view(graphiql=settings.DEBUG))),
+    path("graphql", csrf_exempt(SentryGraphQLView.as_view(graphiql=settings.DEBUG))),
 ]
 
 

--- a/kukkuu/views.py
+++ b/kukkuu/views.py
@@ -1,0 +1,20 @@
+import sentry_sdk
+from graphene_django.views import GraphQLView
+
+
+class SentryGraphQLView(GraphQLView):
+    def execute_graphql_request(self, request, data, query, *args, **kwargs):
+        """Extract any exceptions and send some of them to Sentry"""
+        result = super().execute_graphql_request(request, data, query, *args, **kwargs)
+        # If 'invalid' is set, it's a bad request
+        if result and result.errors and not result.invalid:
+            self._capture_sentry_exceptions(result.errors, query)
+        return result
+
+    def _capture_sentry_exceptions(self, errors, query):
+        with sentry_sdk.configure_scope() as scope:
+            scope.set_extra("graphql_query", query)
+            for error in errors:
+                if hasattr(error, "original_error"):
+                    error = error.original_error
+                sentry_sdk.capture_exception(error)


### PR DESCRIPTION
Added logic that sends all exceptions to Sentry, with the exception (hehehe) of:
* Bad Request type exceptions
* custom `KukkuuGraphQLError`s, which are meant for returning errors from the API which we don't want to Sentry

The PR contains also one unrelated bug fix.