### PR TITLE
KK-147 | Block mutations according to the usage flow

### DIFF
--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -236,10 +236,10 @@ snapshots["test_update_child_mutation_should_have_no_required_fields 1"] = {
     "data": {
         "updateChild": {
             "child": {
-                "birthdate": "2019-09-08",
-                "firstName": "John",
-                "lastName": "Terrell",
-                "postalCode": "77671",
+                "birthdate": "2019-09-06",
+                "firstName": "Katherine",
+                "lastName": "Wells",
+                "postalCode": "15910",
             }
         }
     }


### PR DESCRIPTION
* SubmitChildrenAndGuardian needs to be used first, and only then
* AddChild cannot be used before SubmitChildrenAndGuardian
* UpdateChild and DeleteChild cannot then be used before
  SubmitChildrenAndGuardian either in practice (because one cannot
  have children to update/delete)