### PR TITLE
Update flake8 excluded folders

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = migrations
+exclude = migrations,snapshots
 max-line-length = 88
 max-complexity = 10
 


### PR DESCRIPTION
Black somehow failed to format multiline strings in snapshots data so flake8 complains about line too long.
Since the data is generated from pytest so it would be ok to exclude the folders