### PR TITLE
Revert "Add max depth for API queries"

### DIFF
--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -185,8 +185,6 @@ LOGGING = {
     "loggers": {"django": {"handlers": ["console"], "level": "ERROR"}},
 }
 
-KUKKUU_QUERY_MAX_DEPTH = 12
-
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.
 local_settings_path = os.path.join(checkout_dir(), "local_settings.py")

--- a/kukkuu/urls.py
+++ b/kukkuu/urls.py
@@ -3,22 +3,12 @@ from django.http import HttpResponse
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 from helusers.admin_site import admin
-from secure_graphene.depth import DepthAnalysisBackend
 
 from kukkuu.views import SentryGraphQLView
 
-gql_backend = DepthAnalysisBackend(
-    max_depth=settings.KUKKUU_QUERY_MAX_DEPTH, execute_params={"executor": None}
-)
-
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path(
-        "graphql",
-        csrf_exempt(
-            SentryGraphQLView.as_view(graphiql=settings.DEBUG, backend=gql_backend)
-        ),
-    ),
+    path("graphql", csrf_exempt(SentryGraphQLView.as_view(graphiql=settings.DEBUG))),
 ]
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -8,8 +8,4 @@ django-parler
 factory-boy
 graphene-django
 psycopg2
-
-# this is not exactly a very widely used package, so be extra cautious if updating this
-secure-graphene==0.1.2
-
 sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ faker==2.0.4              # via factory-boy
 future==0.17.1            # via pyjwkest, python-jose
 graphene-django==2.6.0
 graphene==2.1.8           # via graphene-django
-graphql-core==2.2.1       # via django-graphql-jwt, graphene, graphene-django, graphql-relay, secure-graphene
+graphql-core==2.2.1       # via django-graphql-jwt, graphene, graphene-django, graphql-relay
 graphql-relay==2.0.0      # via graphene
 idna==2.8                 # via requests
 jinja2==2.10.3            # via django-ilmoitin
@@ -42,7 +42,6 @@ pytz==2019.3              # via django
 requests==2.22.0          # via django-anymail, django-helusers, pyjwkest
 rsa==4.0                  # via python-jose
 rx==1.6.1                 # via graphql-core
-secure-graphene==0.1.2
 sentry-sdk==0.12.3
 singledispatch==3.4.0.3   # via graphene-django
 six==1.12.0               # via django-anymail, django-mailer, faker, graphene, graphene-django, graphql-core, graphql-relay, promise, pyjwkest, python-dateutil, python-jose, singledispatch


### PR DESCRIPTION
This reverts commit 1e8072be65351d127e26c4988da2971122c4c85f.

Adding secure-django broke something, at least GraphiQL.