### PR TITLE
Make OIDC_LEEWAY longer

### DIFF
--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -166,6 +166,8 @@ OIDC_API_TOKEN_AUTH = {
     "REQUIRE_API_SCOPE_FOR_AUTHENTICATION": env.bool("TOKEN_AUTH_REQUIRE_SCOPE_PREFIX"),
 }
 
+OIDC_AUTH = {"OIDC_LEEWAY": 60 * 60}
+
 SITE_ID = 1
 
 PARLER_LANGUAGES = {SITE_ID: ({"code": "fi"}, {"code": "sv"}, {"code": "en"})}


### PR DESCRIPTION
We want to use a token's exp value instead of rejecting all tokens
older than 10mins.