### PR TITLE
KK-181  KK-182 | Update  & delete events/venues/occurrences

### DIFF
--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -5,8 +5,10 @@ from django.test import RequestFactory
 from freezegun import freeze_time
 from graphene.test import Client
 
+from events.factories import EventFactory, OccurrenceFactory
 from kukkuu.schema import schema
 from users.factories import GuardianFactory, UserFactory
+from venues.factories import VenueFactory
 
 
 @pytest.fixture(autouse=True)
@@ -41,6 +43,21 @@ def staff_api_client():
 @pytest.fixture
 def guardian_api_client():
     return _create_api_client_with_user(UserFactory(guardian=GuardianFactory()))
+
+
+@pytest.fixture
+def event():
+    return EventFactory()
+
+
+@pytest.fixture
+def venue():
+    return VenueFactory()
+
+
+@pytest.fixture
+def occurrence():
+    return OccurrenceFactory()
 
 
 def _create_api_client_with_user(user):

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,6 +1,21 @@
+from django.db import transaction
+
+
 def update_object(obj, data):
     if not data:
         return
     for k, v in data.items():
         setattr(obj, k, v)
     obj.save()
+
+
+@transaction.atomic
+def update_object_with_translations(model, model_data):
+    translations_input = model_data.pop("translations", None)
+    delete_translations_input = model_data.pop("delete_translations", None)
+
+    if translations_input or delete_translations_input:
+        model.create_or_update_translations(
+            translations_input, delete_translations_input
+        )
+    update_object(model, model_data)

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -14,35 +14,18 @@ snapshots["test_events_query_normal_user 1"] = {
                     "node": {
                         "capacityPerOccurrence": 805,
                         "createdAt": "2020-12-12T00:00:00+00:00",
-                        "duration": 181,
+                        "duration": 197,
                         "image": "spring.jpg",
-                        "occurrences": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "time": "1986-12-12T16:40:48+00:00",
-                                        "venue": {
-                                            "translations": [
-                                                {
-                                                    "description": "Later evening southern would according strong. Analysis season project executive entire.",
-                                                    "languageCode": "FI",
-                                                    "name": "Subject town range.",
-                                                }
-                                            ]
-                                        },
-                                    }
-                                }
-                            ]
-                        },
+                        "occurrences": {"edges": []},
                         "participantsPerInvite": "FAMILY",
                         "publishedAt": "1986-02-27T01:22:35+00:00",
                         "translations": [
                             {
-                                "description": """Least then top sing. Serious listen police shake. Page box child care any concern.
+                                "description": """Serious listen police shake. Page box child care any concern.
 Agree room laugh prevent make. Our very television beat at success decade.""",
                                 "languageCode": "FI",
-                                "name": "Worker position late leg him president.",
-                                "shortDescription": "Together history perform.",
+                                "name": "Free heart significant machine try.",
+                                "shortDescription": "Perform in weight success answer.",
                             }
                         ],
                         "updatedAt": "2020-12-12T00:00:00+00:00",
@@ -193,7 +176,49 @@ snapshots["test_add_occurrence_staff_user 1"] = {
             "occurrence": {
                 "event": {"id": "RXZlbnROb2RlOjg="},
                 "time": "1986-12-12T16:40:48+00:00",
+                "venue": {"id": "VmVudWVOb2RlOjQ="},
+            }
+        }
+    }
+}
+
+snapshots["test_update_occurrence_staff_user 1"] = {
+    "data": {
+        "updateOccurrence": {
+            "occurrence": {
+                "event": {"id": "RXZlbnROb2RlOjk="},
+                "id": "T2NjdXJyZW5jZU5vZGU6NQ==",
+                "time": "1986-12-12T16:40:48+00:00",
                 "venue": {"id": "VmVudWVOb2RlOjU="},
+            }
+        }
+    }
+}
+
+snapshots["test_update_event_staff_user 1"] = {
+    "data": {
+        "updateEvent": {
+            "event": {
+                "capacityPerOccurrence": 30,
+                "duration": 1000,
+                "id": "RXZlbnROb2RlOjEx",
+                "occurrences": {"edges": []},
+                "participantsPerInvite": "FAMILY",
+                "translations": [
+                    {
+                        "description": "desc",
+                        "languageCode": "SV",
+                        "name": "Event test in suomi",
+                        "shortDescription": "Short desc",
+                    },
+                    {
+                        "description": """Serious listen police shake. Page box child care any concern.
+Agree room laugh prevent make. Our very television beat at success decade.""",
+                        "languageCode": "FI",
+                        "name": "Free heart significant machine try.",
+                        "shortDescription": "Perform in weight success answer.",
+                    },
+                ],
             }
         }
     }

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -172,6 +172,7 @@ SITE_ID = 1
 
 PARLER_LANGUAGES = {SITE_ID: ({"code": "fi"}, {"code": "sv"}, {"code": "en"})}
 
+PARLER_SUPPORTED_LANGUAGE_CODES = [x["code"] for x in PARLER_LANGUAGES[SITE_ID]]
 
 GRAPHENE = {
     "SCHEMA": "kukkuu.schema.schema",

--- a/venues/tests/snapshots/snap_test_api.py
+++ b/venues/tests/snapshots/snap_test_api.py
@@ -126,3 +126,25 @@ snapshots["test_add_venue_staff_user 1"] = {
         }
     }
 }
+
+snapshots["test_update_venue_staff_user 1"] = {
+    "data": {
+        "updateVenue": {
+            "venue": {
+                "id": "VmVudWVOb2RlOjEy",
+                "translations": [
+                    {
+                        "accessibilityInfo": "Accessibility info",
+                        "additionalInfo": "Additional info",
+                        "address": "Address",
+                        "arrivalInstructions": "Arrival instruction",
+                        "description": "Venue description",
+                        "languageCode": "FI",
+                        "name": "Venue name",
+                        "wwwUrl": "www.url.com",
+                    }
+                ],
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since `Event` and `Venue` have 1-n relationships with `Occurrence`. We have somehow to be able to create/update/delete occurrences from event and venue as well.

As I don't think we'll have the use case where occurrence created while updating `Venue`, I only made the nested CRUD in `Event`. For simplicity, for now only add and delete occurrence are supported in event update mutation.

Regarding translations, for some reason `django-parler` couldn't be able to recognise unsupported language code when creating new `translation`. A garbage row will be created in DB when someone trying to create a weird language code translation, and the app will break when we query that damaged object next time. I added a setting variable to avoid it. So the the model will ignore them when creating translations, unless the `languageCode` belongs to `PARLER_SUPPORTED_LANGUAGE_CODES`
