### PR TITLE
Make get api public

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We follow the basic config, without any modifications. Basic `black` commands:
 Or you can use [`pre-commit`](https://pre-commit.com/) to quickly format your code before committing.
 
 
-1. Install `pre-commit` (there are many ways to do but let's use pip as an example:
+1. Install `pre-commit` (there are many ways to do but let's use pip as an example):
     * `pip install pre-commit`
 2. Set up git hooks from `.pre-commit-config.yaml`, run this command from project root:
     * `pre-commit install`

--- a/events/schema.py
+++ b/events/schema.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from graphene import relay
 from graphene_django import DjangoConnectionField, DjangoObjectType
 from graphene_file_upload.scalars import Upload
-from graphql_jwt.decorators import login_required, staff_member_required
+from graphql_jwt.decorators import staff_member_required
 from graphql_relay import from_global_id
 
 from common.utils import update_object, update_object_with_translations
@@ -27,13 +27,10 @@ class EventNode(DjangoObjectType):
         interfaces = (relay.Node,)
 
     @classmethod
-    @login_required
-    # TODO: For now only logged in users can see events
     def get_queryset(cls, queryset, info):
         return queryset.order_by("-created_at")
 
     @classmethod
-    @login_required
     def get_node(cls, info, id):
         return super().get_node(info, id)
 
@@ -44,13 +41,10 @@ class OccurrenceNode(DjangoObjectType):
     time = graphene.DateTime()
 
     @classmethod
-    @login_required
-    # TODO: For now only logged in users can see occurrences
     def get_queryset(cls, queryset, info):
         return queryset.order_by("-created_at")
 
     @classmethod
-    @login_required
     def get_node(cls, info, id):
         return super().get_node(info, id)
 

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -201,7 +201,6 @@ snapshots["test_update_event_staff_user 1"] = {
             "event": {
                 "capacityPerOccurrence": 30,
                 "duration": 1000,
-                "id": "RXZlbnROb2RlOjEz",
                 "occurrences": {"edges": []},
                 "participantsPerInvite": "FAMILY",
                 "translations": [

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -174,9 +174,9 @@ snapshots["test_add_occurrence_staff_user 1"] = {
     "data": {
         "addOccurrence": {
             "occurrence": {
-                "event": {"id": "RXZlbnROb2RlOjg="},
+                "event": {"id": "RXZlbnROb2RlOjEw"},
                 "time": "1986-12-12T16:40:48+00:00",
-                "venue": {"id": "VmVudWVOb2RlOjQ="},
+                "venue": {"id": "VmVudWVOb2RlOjU="},
             }
         }
     }
@@ -186,10 +186,10 @@ snapshots["test_update_occurrence_staff_user 1"] = {
     "data": {
         "updateOccurrence": {
             "occurrence": {
-                "event": {"id": "RXZlbnROb2RlOjk="},
-                "id": "T2NjdXJyZW5jZU5vZGU6NQ==",
+                "event": {"id": "RXZlbnROb2RlOjEx"},
+                "id": "T2NjdXJyZW5jZU5vZGU6Ng==",
                 "time": "1986-12-12T16:40:48+00:00",
-                "venue": {"id": "VmVudWVOb2RlOjU="},
+                "venue": {"id": "VmVudWVOb2RlOjY="},
             }
         }
     }
@@ -201,7 +201,7 @@ snapshots["test_update_event_staff_user 1"] = {
             "event": {
                 "capacityPerOccurrence": 30,
                 "duration": 1000,
-                "id": "RXZlbnROb2RlOjEx",
+                "id": "RXZlbnROb2RlOjEz",
                 "occurrences": {"edges": []},
                 "participantsPerInvite": "FAMILY",
                 "translations": [
@@ -220,6 +220,146 @@ Agree room laugh prevent make. Our very television beat at success decade.""",
                     },
                 ],
             }
+        }
+    }
+}
+
+snapshots["test_events_query_unauthenticated 1"] = {
+    "data": {
+        "events": {
+            "edges": [
+                {
+                    "node": {
+                        "capacityPerOccurrence": 394,
+                        "createdAt": "2020-12-12T00:00:00+00:00",
+                        "duration": 170,
+                        "image": "enter.jpg",
+                        "occurrences": {"edges": []},
+                        "participantsPerInvite": "CHILD_AND_GUARDIAN",
+                        "publishedAt": "2007-12-04T20:40:56+00:00",
+                        "translations": [
+                            {
+                                "description": "Success answer entire increase thank. Least then top sing. Serious listen police shake.",
+                                "languageCode": "FI",
+                                "name": "Record card my. Sure sister return.",
+                                "shortDescription": "Position late leg him president compare. Hotel town south.",
+                            }
+                        ],
+                        "updatedAt": "2020-12-12T00:00:00+00:00",
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots["test_event_query_unauthenticated 1"] = {
+    "data": {
+        "event": {
+            "capacityPerOccurrence": 394,
+            "createdAt": "2020-12-12T00:00:00+00:00",
+            "duration": 170,
+            "image": "enter.jpg",
+            "occurrences": {"edges": []},
+            "participantsPerInvite": "CHILD_AND_GUARDIAN",
+            "publishedAt": "2007-12-04T20:40:56+00:00",
+            "translations": [
+                {
+                    "description": "Success answer entire increase thank. Least then top sing. Serious listen police shake.",
+                    "languageCode": "FI",
+                    "name": "Record card my. Sure sister return.",
+                    "shortDescription": "Position late leg him president compare. Hotel town south.",
+                }
+            ],
+            "updatedAt": "2020-12-12T00:00:00+00:00",
+        }
+    }
+}
+
+snapshots["test_occurrences_query_unauthenticated 1"] = {
+    "data": {
+        "occurrences": {
+            "edges": [
+                {
+                    "node": {
+                        "event": {
+                            "capacityPerOccurrence": 805,
+                            "duration": 12,
+                            "image": "spring.jpg",
+                            "participantsPerInvite": "FAMILY",
+                            "publishedAt": "1986-02-27T01:22:35+00:00",
+                            "translations": [
+                                {
+                                    "description": """Least then top sing. Serious listen police shake. Page box child care any concern.
+Agree room laugh prevent make. Our very television beat at success decade.""",
+                                    "languageCode": "FI",
+                                    "name": "Card my side sure sister return ten. Exactly guy site late eat.",
+                                    "shortDescription": "Start majority government together history perform.",
+                                }
+                            ],
+                        },
+                        "time": "1970-12-20T22:29:18+00:00",
+                        "venue": {
+                            "translations": [
+                                {
+                                    "accessibilityInfo": "Enjoy office water those notice medical. Already name likely behind mission network. Think significant land especially can quite.",
+                                    "additionalInfo": """Prevent pressure point. Voice radio happen color scene.
+Assume training seek full several. Authority develop identify ready.""",
+                                    "address": """1449 Hill Squares
+South Zacharyborough, CO 33337""",
+                                    "arrivalInstructions": """Last appear experience seven. Throw wrong party wall agency customer clear. Control as receive cup.
+Family around year off. Sense person the probably.""",
+                                    "description": "Later evening southern would according strong. Analysis season project executive entire.",
+                                    "languageCode": "FI",
+                                    "name": "Subject town range.",
+                                    "wwwUrl": "http://brooks.org/",
+                                }
+                            ]
+                        },
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots["test_occurrence_query_unauthenticated 1"] = {
+    "data": {
+        "occurrence": {
+            "event": {
+                "capacityPerOccurrence": 805,
+                "duration": 12,
+                "image": "spring.jpg",
+                "participantsPerInvite": "FAMILY",
+                "publishedAt": "1986-02-27T01:22:35+00:00",
+                "translations": [
+                    {
+                        "description": """Least then top sing. Serious listen police shake. Page box child care any concern.
+Agree room laugh prevent make. Our very television beat at success decade.""",
+                        "languageCode": "FI",
+                        "name": "Card my side sure sister return ten. Exactly guy site late eat.",
+                        "shortDescription": "Start majority government together history perform.",
+                    }
+                ],
+            },
+            "time": "1970-12-20T22:29:18+00:00",
+            "venue": {
+                "translations": [
+                    {
+                        "accessibilityInfo": "Enjoy office water those notice medical. Already name likely behind mission network. Think significant land especially can quite.",
+                        "additionalInfo": """Prevent pressure point. Voice radio happen color scene.
+Assume training seek full several. Authority develop identify ready.""",
+                        "address": """1449 Hill Squares
+South Zacharyborough, CO 33337""",
+                        "arrivalInstructions": """Last appear experience seven. Throw wrong party wall agency customer clear. Control as receive cup.
+Family around year off. Sense person the probably.""",
+                        "description": "Later evening southern would according strong. Analysis season project executive entire.",
+                        "languageCode": "FI",
+                        "name": "Subject town range.",
+                        "wwwUrl": "http://brooks.org/",
+                    }
+                ]
+            },
         }
     }
 }

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -199,7 +199,6 @@ UPDATE_EVENT_MUTATION = """
 mutation UpdateEvent($input: UpdateEventMutationInput!) {
   updateEvent(input: $input) {
     event {
-      id,
       translations{
         name
         shortDescription

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -304,10 +304,10 @@ mutation DeleteOccurrence($input: DeleteOccurrenceMutationInput!) {
 """
 
 
-def test_events_query_unauthenticated(api_client):
+def test_events_query_unauthenticated(api_client, event, snapshot):
     executed = api_client.execute(EVENTS_QUERY)
 
-    assert_permission_denied(executed)
+    snapshot.assert_match(executed)
 
 
 def test_events_query_normal_user(snapshot, user_api_client, event):
@@ -316,11 +316,11 @@ def test_events_query_normal_user(snapshot, user_api_client, event):
     snapshot.assert_match(executed)
 
 
-def test_event_query_unauthenticated(api_client, event):
+def test_event_query_unauthenticated(api_client, event, snapshot):
     variables = {"id": to_global_id("EventNode", event.id)}
     executed = api_client.execute(EVENT_QUERY, variables=variables)
 
-    assert_permission_denied(executed)
+    snapshot.assert_match(executed)
 
 
 def test_event_query_normal_user(snapshot, user_api_client, event):
@@ -330,10 +330,10 @@ def test_event_query_normal_user(snapshot, user_api_client, event):
     snapshot.assert_match(executed)
 
 
-def test_occurrences_query_unauthenticated(api_client):
+def test_occurrences_query_unauthenticated(api_client, occurrence, snapshot):
     executed = api_client.execute(OCCURRENCES_QUERY)
 
-    assert_permission_denied(executed)
+    snapshot.assert_match(executed)
 
 
 def test_occurrences_query_normal_user(snapshot, user_api_client, occurrence):
@@ -342,11 +342,11 @@ def test_occurrences_query_normal_user(snapshot, user_api_client, occurrence):
     snapshot.assert_match(executed)
 
 
-def test_occurrence_query_unauthenticated(api_client, occurrence):
+def test_occurrence_query_unauthenticated(api_client, occurrence, snapshot):
     variables = {"id": to_global_id("OccurrenceNode", occurrence.id)}
     executed = api_client.execute(OCCURRENCE_QUERY, variables=variables)
 
-    assert_permission_denied(executed)
+    snapshot.assert_match(executed)
 
 
 def test_occurrence_query_normal_user(snapshot, user_api_client, occurrence):

--- a/venues/schema.py
+++ b/venues/schema.py
@@ -3,7 +3,7 @@ from django.apps import apps
 from django.db import transaction
 from graphene import relay
 from graphene_django import DjangoConnectionField, DjangoObjectType
-from graphql_jwt.decorators import login_required, staff_member_required
+from graphql_jwt.decorators import staff_member_required
 from graphql_relay import from_global_id
 
 from common.utils import update_object_with_translations
@@ -25,13 +25,10 @@ class VenueNode(DjangoObjectType):
         interfaces = (relay.Node,)
 
     @classmethod
-    @login_required
-    # TODO: For now only logged in users can see venues
     def get_queryset(cls, queryset, info):
         return queryset.order_by("-created_at")
 
     @classmethod
-    @login_required
     def get_node(cls, info, id):
         return super().get_node(info, id)
 

--- a/venues/tests/snapshots/snap_test_api.py
+++ b/venues/tests/snapshots/snap_test_api.py
@@ -12,44 +12,19 @@ snapshots["test_venues_query_normal_user 1"] = {
             "edges": [
                 {
                     "node": {
-                        "occurrences": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "event": {
-                                            "capacityPerOccurrence": 805,
-                                            "duration": 181,
-                                            "image": "spring.jpg",
-                                            "participantsPerInvite": "FAMILY",
-                                            "publishedAt": "1986-02-27T01:22:35+00:00",
-                                            "translations": [
-                                                {
-                                                    "description": """Least then top sing. Serious listen police shake. Page box child care any concern.
-Agree room laugh prevent make. Our very television beat at success decade.""",
-                                                    "languageCode": "FI",
-                                                    "name": "Worker position late leg him president.",
-                                                    "shortDescription": "Together history perform.",
-                                                }
-                                            ],
-                                        },
-                                        "time": "1986-12-12T16:40:48+00:00",
-                                    }
-                                }
-                            ]
-                        },
+                        "occurrences": {"edges": []},
                         "translations": [
                             {
-                                "accessibilityInfo": "Enjoy office water those notice medical. Already name likely behind mission network. Think significant land especially can quite.",
-                                "additionalInfo": """Prevent pressure point. Voice radio happen color scene.
-Assume training seek full several. Authority develop identify ready.""",
-                                "address": """1449 Hill Squares
-South Zacharyborough, CO 33337""",
-                                "arrivalInstructions": """Last appear experience seven. Throw wrong party wall agency customer clear. Control as receive cup.
-Family around year off. Sense person the probably.""",
-                                "description": "Later evening southern would according strong. Analysis season project executive entire.",
+                                "accessibilityInfo": "From daughter order stay sign discover eight. Toward scientist service wonder everything. Middle moment strong hand push book and interesting.",
+                                "additionalInfo": "Training thought price. Effort clear and local challenge box. Care figure mention wrong when lead involve.",
+                                "address": """48830 Whitehead Rapid Suite 548
+Whiteview, TN 11309""",
+                                "arrivalInstructions": "Benefit treat final central. Past ready join enjoy. Huge get this success commercial recently from.",
+                                "description": """Perform in weight success answer. Hospital number lose least then. Beyond than trial western.
+Page box child care any concern. Defense level church use.""",
                                 "languageCode": "FI",
-                                "name": "Subject town range.",
-                                "wwwUrl": "http://brooks.org/",
+                                "name": "Free heart significant machine try.",
+                                "wwwUrl": "http://www.hernandez.net/",
                             }
                         ],
                     }
@@ -62,44 +37,19 @@ Family around year off. Sense person the probably.""",
 snapshots["test_venue_query_normal_user 1"] = {
     "data": {
         "venue": {
-            "occurrences": {
-                "edges": [
-                    {
-                        "node": {
-                            "event": {
-                                "capacityPerOccurrence": 805,
-                                "duration": 181,
-                                "image": "spring.jpg",
-                                "participantsPerInvite": "FAMILY",
-                                "publishedAt": "1986-02-27T01:22:35+00:00",
-                                "translations": [
-                                    {
-                                        "description": """Least then top sing. Serious listen police shake. Page box child care any concern.
-Agree room laugh prevent make. Our very television beat at success decade.""",
-                                        "languageCode": "FI",
-                                        "name": "Worker position late leg him president.",
-                                        "shortDescription": "Together history perform.",
-                                    }
-                                ],
-                            },
-                            "time": "1986-12-12T16:40:48+00:00",
-                        }
-                    }
-                ]
-            },
+            "occurrences": {"edges": []},
             "translations": [
                 {
-                    "accessibilityInfo": "Enjoy office water those notice medical. Already name likely behind mission network. Think significant land especially can quite.",
-                    "additionalInfo": """Prevent pressure point. Voice radio happen color scene.
-Assume training seek full several. Authority develop identify ready.""",
-                    "address": """1449 Hill Squares
-South Zacharyborough, CO 33337""",
-                    "arrivalInstructions": """Last appear experience seven. Throw wrong party wall agency customer clear. Control as receive cup.
-Family around year off. Sense person the probably.""",
-                    "description": "Later evening southern would according strong. Analysis season project executive entire.",
+                    "accessibilityInfo": "From daughter order stay sign discover eight. Toward scientist service wonder everything. Middle moment strong hand push book and interesting.",
+                    "additionalInfo": "Training thought price. Effort clear and local challenge box. Care figure mention wrong when lead involve.",
+                    "address": """48830 Whitehead Rapid Suite 548
+Whiteview, TN 11309""",
+                    "arrivalInstructions": "Benefit treat final central. Past ready join enjoy. Huge get this success commercial recently from.",
+                    "description": """Perform in weight success answer. Hospital number lose least then. Beyond than trial western.
+Page box child care any concern. Defense level church use.""",
                     "languageCode": "FI",
-                    "name": "Subject town range.",
-                    "wwwUrl": "http://brooks.org/",
+                    "name": "Free heart significant machine try.",
+                    "wwwUrl": "http://www.hernandez.net/",
                 }
             ],
         }
@@ -131,7 +81,7 @@ snapshots["test_update_venue_staff_user 1"] = {
     "data": {
         "updateVenue": {
             "venue": {
-                "id": "VmVudWVOb2RlOjEy",
+                "id": "VmVudWVOb2RlOjY=",
                 "translations": [
                     {
                         "accessibilityInfo": "Accessibility info",
@@ -145,6 +95,64 @@ snapshots["test_update_venue_staff_user 1"] = {
                     }
                 ],
             }
+        }
+    }
+}
+
+snapshots["test_venues_query_unauthenticated 1"] = {
+    "data": {
+        "venues": {
+            "edges": [
+                {
+                    "node": {
+                        "occurrences": {"edges": []},
+                        "translations": [
+                            {
+                                "accessibilityInfo": """Range north skin watch.
+Condition like lay still bar. From daughter order stay sign discover eight. Toward scientist service wonder everything.""",
+                                "additionalInfo": """Local challenge box myself last.
+Experience seven Republican throw wrong party wall.
+Policy data control as receive.
+Teacher subject family around year. Space speak sense person the probably deep.""",
+                                "address": """5816 Justin Spring
+Thomasfort, SC 31620""",
+                                "arrivalInstructions": "Good father boy economy the. Enjoy office water those notice medical. Already name likely behind mission network.",
+                                "description": """Position late leg him president compare. Hotel town south. Together history perform.
+Success answer entire increase thank. Least then top sing. Serious listen police shake.""",
+                                "languageCode": "FI",
+                                "name": "Record card my. Sure sister return.",
+                                "wwwUrl": "https://luna.info/",
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots["test_venue_query_unauthenticated 1"] = {
+    "data": {
+        "venue": {
+            "occurrences": {"edges": []},
+            "translations": [
+                {
+                    "accessibilityInfo": """Range north skin watch.
+Condition like lay still bar. From daughter order stay sign discover eight. Toward scientist service wonder everything.""",
+                    "additionalInfo": """Local challenge box myself last.
+Experience seven Republican throw wrong party wall.
+Policy data control as receive.
+Teacher subject family around year. Space speak sense person the probably deep.""",
+                    "address": """5816 Justin Spring
+Thomasfort, SC 31620""",
+                    "arrivalInstructions": "Good father boy economy the. Enjoy office water those notice medical. Already name likely behind mission network.",
+                    "description": """Position late leg him president compare. Hotel town south. Together history perform.
+Success answer entire increase thank. Least then top sing. Serious listen police shake.""",
+                    "languageCode": "FI",
+                    "name": "Record card my. Sure sister return.",
+                    "wwwUrl": "https://luna.info/",
+                }
+            ],
         }
     }
 }

--- a/venues/tests/snapshots/snap_test_api.py
+++ b/venues/tests/snapshots/snap_test_api.py
@@ -81,7 +81,6 @@ snapshots["test_update_venue_staff_user 1"] = {
     "data": {
         "updateVenue": {
             "venue": {
-                "id": "VmVudWVOb2RlOjY=",
                 "translations": [
                     {
                         "accessibilityInfo": "Accessibility info",
@@ -93,7 +92,7 @@ snapshots["test_update_venue_staff_user 1"] = {
                         "name": "Venue name",
                         "wwwUrl": "www.url.com",
                     }
-                ],
+                ]
             }
         }
     }

--- a/venues/tests/test_api.py
+++ b/venues/tests/test_api.py
@@ -173,28 +173,26 @@ mutation DeleteVenue($input: DeleteVenueMutationInput!) {
 """
 
 
-def test_venues_query_unauthenticated(api_client):
+def test_venues_query_unauthenticated(api_client, snapshot, venue):
     executed = api_client.execute(VENUES_QUERY)
 
-    assert_permission_denied(executed)
+    snapshot.assert_match(executed)
 
 
-def test_venues_query_normal_user(snapshot, user_api_client, occurrence):
+def test_venues_query_normal_user(snapshot, user_api_client, venue):
     executed = user_api_client.execute(VENUES_QUERY)
 
     snapshot.assert_match(executed)
 
 
-def test_venue_query_unauthenticated(api_client, occurrence):
-    venue = occurrence.venue
+def test_venue_query_unauthenticated(api_client, venue, snapshot):
     variables = {"id": to_global_id("VenueNode", venue.id)}
     executed = api_client.execute(VENUE_QUERY, variables=variables)
 
-    assert_permission_denied(executed)
+    snapshot.assert_match(executed)
 
 
-def test_venue_query_normal_user(snapshot, user_api_client, occurrence):
-    venue = occurrence.venue
+def test_venue_query_normal_user(snapshot, user_api_client, venue):
     variables = {"id": to_global_id("VenueNode", venue.id)}
     executed = user_api_client.execute(VENUE_QUERY, variables=variables)
 

--- a/venues/tests/test_api.py
+++ b/venues/tests/test_api.py
@@ -130,7 +130,6 @@ UPDATE_VENUE_MUTATION = """
 mutation updateVenue($input: UpdateVenueMutationInput!) {
   updateVenue(input: $input) {
     venue {
-      id
       translations{
         languageCode
         name


### PR DESCRIPTION
In order to support event page, backend needs to make the events/venues/occurrence API public, so user might be able to see events without login 