### PR TITLE
KK-273 | Fix API queries to use RelationshipTypeEnum like mutations do

### DIFF
--- a/children/schema.py
+++ b/children/schema.py
@@ -41,18 +41,20 @@ class ChildNode(DjangoObjectType):
             return None
 
 
+class RelationshipTypeEnum(graphene.Enum):
+    PARENT = "parent"
+    OTHER_GUARDIAN = "other_guardian"
+    OTHER_RELATION = "other_relation"
+    ADVOCATE = "advocate"
+
+
 class RelationshipNode(DjangoObjectType):
     class Meta:
         model = Relationship
         interfaces = (relay.Node,)
         fields = ("type", "child", "guardian")
 
-
-class RelationshipTypeEnum(graphene.Enum):
-    PARENT = "parent"
-    OTHER_GUARDIAN = "other_guardian"
-    OTHER_RELATION = "other_relation"
-    ADVOCATE = "advocate"
+    type = graphene.Field(RelationshipTypeEnum)
 
 
 class RelationshipInput(graphene.InputObjectType):


### PR DESCRIPTION
Previously queries returned relationship type as RelationshipType while
mutations used RelationshipTypeEnum.