### PR TITLE
Fix occurrences remaining capacity

### DIFF
--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -250,15 +250,50 @@ snapshots["test_get_available_events 1"] = {
         "child": {
             "availableEvents": {
                 "edges": [
-                    {"node": {"createdAt": "2020-12-12T00:00:00+00:00"}},
-                    {"node": {"createdAt": "2020-12-12T00:00:00+00:00"}},
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 736}}]
+                            },
+                        }
+                    },
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 697}}]
+                            },
+                        }
+                    },
                 ]
             },
             "pastEvents": {
                 "edges": [
-                    {"node": {"createdAt": "2020-12-12T00:00:00+00:00"}},
-                    {"node": {"createdAt": "2020-12-12T00:00:00+00:00"}},
-                    {"node": {"createdAt": "2020-12-12T00:00:00+00:00"}},
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 502}}]
+                            },
+                        }
+                    },
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 890}}]
+                            },
+                        }
+                    },
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 885}}]
+                            },
+                        }
+                    },
                 ]
             },
         }
@@ -270,16 +305,58 @@ snapshots["test_get_past_events 1"] = {
         "child": {
             "availableEvents": {
                 "edges": [
-                    {"node": {"createdAt": "2020-12-12T00:00:00+00:00"}},
-                    {"node": {"createdAt": "2020-12-12T00:00:00+00:00"}},
-                    {"node": {"createdAt": "2020-12-12T00:00:00+00:00"}},
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 512}}]
+                            },
+                        }
+                    },
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 736}}]
+                            },
+                        }
+                    },
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 697}}]
+                            },
+                        }
+                    },
                 ]
             },
             "pastEvents": {
                 "edges": [
-                    {"node": {"createdAt": "2020-12-12T00:00:00+00:00"}},
-                    {"node": {"createdAt": "2020-12-12T00:00:00+00:00"}},
-                    {"node": {"createdAt": "2020-12-12T00:00:00+00:00"}},
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 501}}]
+                            },
+                        }
+                    },
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 890}}]
+                            },
+                        }
+                    },
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 885}}]
+                            },
+                        }
+                    },
                 ]
             },
         }

--- a/children/tests/test_api.py
+++ b/children/tests/test_api.py
@@ -298,6 +298,13 @@ query Child($id: ID!) {
       edges{
         node{
           createdAt
+          occurrences{
+            edges{
+              node{
+                remainingCapacity
+              }
+            }
+          }
         }
       }
     }
@@ -305,6 +312,13 @@ query Child($id: ID!) {
       edges{
         node{
           createdAt
+          occurrences{
+            edges{
+              node{
+                remainingCapacity
+              }
+            }
+          }
         }
       }
     }

--- a/events/schema.py
+++ b/events/schema.py
@@ -65,6 +65,11 @@ class EventNode(DjangoObjectType):
             return info.context.build_absolute_uri(self.image.url)
         return ""
 
+    def resolve_occurrences(self, info, **kwargs):
+        return self.occurrences.annotate(
+            enrolments_count=Count("enrolments", distinct=True)
+        ).order_by("time")
+
 
 class EventConnection(Connection):
     class Meta:
@@ -80,11 +85,9 @@ class OccurrenceNode(DjangoObjectType):
     @classmethod
     @login_required
     def get_queryset(cls, queryset, info):
-        return (
-            queryset.annotate(enrolments_count=Count("enrolments"))
-            .select_related("event")
-            .order_by("time")
-        )
+        return queryset.annotate(
+            enrolments_count=Count("enrolments", distinct=True)
+        ).order_by("time")
 
     @classmethod
     @login_required

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -19,7 +19,25 @@ Agree room laugh prevent make. Our very television beat at success decade.""",
                         "duration": 197,
                         "image": "http://testserver/media/spring.jpg",
                         "name": "Free heart significant machine try.",
-                        "occurrences": {"edges": []},
+                        "occurrences": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "remainingCapacity": 805,
+                                        "time": "1986-02-27T01:22:35+00:00",
+                                        "venue": {
+                                            "translations": [
+                                                {
+                                                    "description": "Later evening southern would according strong. Analysis season project executive entire.",
+                                                    "languageCode": "FI",
+                                                    "name": "Subject town range.",
+                                                }
+                                            ]
+                                        },
+                                    }
+                                }
+                            ]
+                        },
                         "participantsPerInvite": "FAMILY",
                         "publishedAt": None,
                         "shortDescription": "Perform in weight success answer.",
@@ -50,7 +68,25 @@ Agree room laugh prevent make. Our very television beat at success decade.""",
             "duration": 197,
             "image": "http://testserver/media/spring.jpg",
             "name": "Free heart significant machine try.",
-            "occurrences": {"edges": []},
+            "occurrences": {
+                "edges": [
+                    {
+                        "node": {
+                            "remainingCapacity": 805,
+                            "time": "1986-02-27T01:22:35+00:00",
+                            "venue": {
+                                "translations": [
+                                    {
+                                        "description": "Later evening southern would according strong. Analysis season project executive entire.",
+                                        "languageCode": "FI",
+                                        "name": "Subject town range.",
+                                    }
+                                ]
+                            },
+                        }
+                    }
+                ]
+            },
             "participantsPerInvite": "FAMILY",
             "publishedAt": None,
             "shortDescription": "Perform in weight success answer.",

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -45,6 +45,7 @@ query Events {
         occurrences {
           edges {
             node {
+              remainingCapacity
               time
               venue {
                 translations{
@@ -86,6 +87,7 @@ query Event($id:ID!) {
       edges{
         node{
           time
+          remainingCapacity
           venue{
             translations{
               name
@@ -383,6 +385,7 @@ def test_events_query_unauthenticated(api_client):
 
 
 def test_events_query_normal_user(snapshot, user_api_client, event):
+    OccurrenceFactory(event=event)
     executed = user_api_client.execute(EVENTS_QUERY)
 
     snapshot.assert_match(executed)
@@ -396,6 +399,7 @@ def test_event_query_unauthenticated(api_client, event):
 
 
 def test_event_query_normal_user(snapshot, user_api_client, event):
+    OccurrenceFactory(event=event)
     variables = {"id": to_global_id("EventNode", event.id)}
     executed = user_api_client.execute(EVENT_QUERY, variables=variables)
 

--- a/venues/schema.py
+++ b/venues/schema.py
@@ -1,6 +1,7 @@
 import graphene
 from django.apps import apps
 from django.db import transaction
+from django.db.models import Count
 from django.utils.translation import get_language
 from graphene import relay
 from graphene_django import DjangoConnectionField, DjangoObjectType
@@ -44,6 +45,15 @@ class VenueNode(DjangoObjectType):
     @login_required
     def get_node(cls, info, id):
         return super().get_node(info, id)
+
+    def resolve_occurrences(self, info, **kwargs):
+        return (
+            self.occurrences.annotate(
+                enrolments_count=Count("enrolments", distinct=True)
+            )
+            .select_related("event")
+            .order_by("time")
+        )
 
 
 class VenueTranslationsInput(graphene.InputObjectType):

--- a/venues/tests/snapshots/snap_test_api.py
+++ b/venues/tests/snapshots/snap_test_api.py
@@ -20,7 +20,32 @@ Whiteview, TN 11309""",
                         "description": """Perform in weight success answer. Hospital number lose least then. Beyond than trial western.
 Page box child care any concern. Defense level church use.""",
                         "name": "Free heart significant machine try.",
-                        "occurrences": {"edges": []},
+                        "occurrences": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "event": {
+                                            "capacityPerOccurrence": 712,
+                                            "duration": 300,
+                                            "image": "http://testserver/media/hand.jpg",
+                                            "participantsPerInvite": "CHILD_AND_GUARDIAN",
+                                            "publishedAt": None,
+                                            "translations": [
+                                                {
+                                                    "description": """Leg simple various be various. College able physical almost. Audience actually send address attorney candidate. Rock tough plant traditional.
+Build natural middle however.""",
+                                                    "languageCode": "EN",
+                                                    "name": "Think turn argue present. Spend prevent pressure point exist.",
+                                                    "shortDescription": "Others not authority develop identify ready.",
+                                                }
+                                            ],
+                                        },
+                                        "remainingCapacity": 712,
+                                        "time": "1984-07-02T07:57:10+00:00",
+                                    }
+                                }
+                            ]
+                        },
                         "translations": [
                             {
                                 "accessibilityInfo": "From daughter order stay sign discover eight. Toward scientist service wonder everything. Middle moment strong hand push book and interesting.",
@@ -54,7 +79,32 @@ Whiteview, TN 11309""",
             "description": """Perform in weight success answer. Hospital number lose least then. Beyond than trial western.
 Page box child care any concern. Defense level church use.""",
             "name": "Free heart significant machine try.",
-            "occurrences": {"edges": []},
+            "occurrences": {
+                "edges": [
+                    {
+                        "node": {
+                            "event": {
+                                "capacityPerOccurrence": 712,
+                                "duration": 300,
+                                "image": "http://testserver/media/hand.jpg",
+                                "participantsPerInvite": "CHILD_AND_GUARDIAN",
+                                "publishedAt": None,
+                                "translations": [
+                                    {
+                                        "description": """Leg simple various be various. College able physical almost. Audience actually send address attorney candidate. Rock tough plant traditional.
+Build natural middle however.""",
+                                        "languageCode": "EN",
+                                        "name": "Think turn argue present. Spend prevent pressure point exist.",
+                                        "shortDescription": "Others not authority develop identify ready.",
+                                    }
+                                ],
+                            },
+                            "remainingCapacity": 712,
+                            "time": "1984-07-02T07:57:10+00:00",
+                        }
+                    }
+                ]
+            },
             "translations": [
                 {
                     "accessibilityInfo": "From daughter order stay sign discover eight. Toward scientist service wonder everything. Middle moment strong hand push book and interesting.",

--- a/venues/tests/test_api.py
+++ b/venues/tests/test_api.py
@@ -4,6 +4,7 @@ import pytest
 from graphql_relay import to_global_id
 
 from common.tests.utils import assert_permission_denied
+from events.factories import OccurrenceFactory
 from venues.models import Venue
 
 
@@ -38,6 +39,7 @@ query Venues {
           edges {
             node {
               time
+              remainingCapacity
               event {
                 translations {
                     name
@@ -84,6 +86,7 @@ query Venue($id: ID!) {
       edges{
         node{
           time
+          remainingCapacity
           event {
               translations {
                 name
@@ -193,6 +196,7 @@ def test_venues_query_unauthenticated(api_client):
 
 
 def test_venues_query_normal_user(snapshot, user_api_client, venue):
+    OccurrenceFactory(venue=venue)
     executed = user_api_client.execute(VENUES_QUERY)
 
     snapshot.assert_match(executed)
@@ -206,6 +210,7 @@ def test_venue_query_unauthenticated(api_client, venue):
 
 
 def test_venue_query_normal_user(snapshot, user_api_client, venue):
+    OccurrenceFactory(venue=venue)
     variables = {"id": to_global_id("VenueNode", venue.id)}
     executed = user_api_client.execute(VENUE_QUERY, variables=variables)
 


### PR DESCRIPTION
When querying occurrences from Event Node or Venue Node:

<img width="746" alt="Screenshot 2020-02-26 at 14 56 06" src="https://user-images.githubusercontent.com/1481118/75346884-4a265e80-58a8-11ea-8ceb-bcf535db8a8b.png">


Turns out `DjangoConnectionField` will discard the annotation declared in OccurrenceNode default queryset so we need to resolve it manually in its parent Node. 