### PR TITLE
Fix child events query to return only published events

### DIFF
--- a/children/schema.py
+++ b/children/schema.py
@@ -48,12 +48,15 @@ class ChildNode(DjangoObjectType):
 
     def resolve_past_events(self, info, **kwargs):
         # TODO: Only return events of the same project
-        return Event.objects.filter(occurrences__time__lt=timezone.now()).distinct()
+        return Event.objects.user_can_view(info.context.user).filter(
+            occurrences__time__lt=timezone.now()
+        )
 
     def resolve_available_events(self, info, **kwargs):
         # TODO: Only return events of the same project
         return (
-            Event.objects.filter(occurrences__time__gte=timezone.now())
+            Event.objects.user_can_view(info.context.user)
+            .filter(occurrences__time__gte=timezone.now())
             .distinct()
             .exclude(occurrences__in=self.occurrences.all())
         )

--- a/children/schema.py
+++ b/children/schema.py
@@ -48,8 +48,10 @@ class ChildNode(DjangoObjectType):
 
     def resolve_past_events(self, info, **kwargs):
         # TODO: Only return events of the same project
-        return Event.objects.user_can_view(info.context.user).filter(
-            occurrences__time__lt=timezone.now()
+        return (
+            Event.objects.user_can_view(info.context.user)
+            .exclude(occurrences__time__gte=timezone.now())
+            .distinct()
         )
 
     def resolve_available_events(self, info, **kwargs):

--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -277,18 +277,10 @@ snapshots["test_get_past_events 1"] = {
                         "node": {
                             "createdAt": "2020-12-12T00:00:00+00:00",
                             "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 697}}]
+                                "edges": [{"node": {"remainingCapacity": 729}}]
                             },
                         }
-                    },
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 735}}]
-                            },
-                        }
-                    },
+                    }
                 ]
             },
         }

--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -257,46 +257,11 @@ snapshots["test_get_available_events 1"] = {
                                 "edges": [{"node": {"remainingCapacity": 697}}]
                             },
                         }
-                    },
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 736}}]
-                            },
-                        }
-                    },
+                    }
                 ]
             },
             "occurrences": {"edges": [{"node": {"time": "2020-12-12T00:00:00+00:00"}}]},
-            "pastEvents": {
-                "edges": [
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 502}}]
-                            },
-                        }
-                    },
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 885}}]
-                            },
-                        }
-                    },
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 890}}]
-                            },
-                        }
-                    },
-                ]
-            },
+            "pastEvents": {"edges": []},
         }
     }
 }
@@ -304,13 +269,15 @@ snapshots["test_get_available_events 1"] = {
 snapshots["test_get_past_events 1"] = {
     "data": {
         "child": {
-            "availableEvents": {
+            "availableEvents": {"edges": []},
+            "occurrences": {"edges": [{"node": {"time": "1969-12-31T22:20:00+00:00"}}]},
+            "pastEvents": {
                 "edges": [
                     {
                         "node": {
                             "createdAt": "2020-12-12T00:00:00+00:00",
                             "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 736}}]
+                                "edges": [{"node": {"remainingCapacity": 735}}]
                             },
                         }
                     },
@@ -319,43 +286,6 @@ snapshots["test_get_past_events 1"] = {
                             "createdAt": "2020-12-12T00:00:00+00:00",
                             "occurrences": {
                                 "edges": [{"node": {"remainingCapacity": 697}}]
-                            },
-                        }
-                    },
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 512}}]
-                            },
-                        }
-                    },
-                ]
-            },
-            "occurrences": {"edges": [{"node": {"time": "1969-12-31T22:20:00+00:00"}}]},
-            "pastEvents": {
-                "edges": [
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 885}}]
-                            },
-                        }
-                    },
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 890}}]
-                            },
-                        }
-                    },
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 501}}]
                             },
                         }
                     },

--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -277,7 +277,7 @@ snapshots["test_get_past_events 1"] = {
                         "node": {
                             "createdAt": "2020-12-12T00:00:00+00:00",
                             "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 735}}]
+                                "edges": [{"node": {"remainingCapacity": 697}}]
                             },
                         }
                     },
@@ -285,7 +285,7 @@ snapshots["test_get_past_events 1"] = {
                         "node": {
                             "createdAt": "2020-12-12T00:00:00+00:00",
                             "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 697}}]
+                                "edges": [{"node": {"remainingCapacity": 735}}]
                             },
                         }
                     },

--- a/children/tests/test_api.py
+++ b/children/tests/test_api.py
@@ -600,13 +600,23 @@ def test_get_available_events(snapshot, guardian_api_client):
         relationship__guardian__user=guardian_api_client.user
     )
     variables = {"id": to_global_id("ChildNode", child.id)}
-    occurrences = OccurrenceFactory.create_batch(3, time=timezone.now())
+    # Unpublished occurrences
+    OccurrenceFactory.create(time=timezone.now())
+
+    # Published occurrences
+    occurrence = OccurrenceFactory.create(
+        time=timezone.now(), event__published_at=timezone.now()
+    )
+    OccurrenceFactory.create(time=timezone.now(), event__published_at=timezone.now())
+
+    # Past occurrences
     OccurrenceFactory.create_batch(
         3, time=datetime(1970, 1, 1, 0, 0, 0, tzinfo=pytz.timezone(settings.TIME_ZONE))
     )
-    EnrolmentFactory(child=child, occurrence=occurrences[0])
+
+    EnrolmentFactory(child=child, occurrence=occurrence)
     executed = guardian_api_client.execute(CHILD_EVENTS_QUERY, variables=variables)
-    assert len(executed["data"]["child"]["availableEvents"]["edges"]) == 2
+    assert len(executed["data"]["child"]["availableEvents"]["edges"]) == 1
     snapshot.assert_match(executed)
 
 
@@ -615,12 +625,27 @@ def test_get_past_events(snapshot, guardian_api_client):
         relationship__guardian__user=guardian_api_client.user
     )
     variables = {"id": to_global_id("ChildNode", child.id)}
-    OccurrenceFactory.create_batch(3, time=timezone.now())
-    past_occurrences = OccurrenceFactory.create_batch(
+    # Unpublished occurrences
+    OccurrenceFactory.create(time=timezone.now())
+
+    # Published occurrences in the past
+    past_occurrence_1 = OccurrenceFactory.create(
+        time=datetime(1970, 1, 1, 0, 0, 0, tzinfo=pytz.timezone(settings.TIME_ZONE)),
+        event__published_at=timezone.now(),
+    )
+    OccurrenceFactory.create(
+        time=datetime(1970, 1, 1, 0, 0, 0, tzinfo=pytz.timezone(settings.TIME_ZONE)),
+        event__published_at=timezone.now(),
+    )
+
+    # Unpublished occurrences in the past
+    OccurrenceFactory.create_batch(
         3, time=datetime(1970, 1, 1, 0, 0, 0, tzinfo=pytz.timezone(settings.TIME_ZONE))
     )
-    EnrolmentFactory(child=child, occurrence=past_occurrences[0])
+
+    EnrolmentFactory(child=child, occurrence=past_occurrence_1)
+
     executed = guardian_api_client.execute(CHILD_EVENTS_QUERY, variables=variables)
     # Still return enroled events if they are past events
-    assert len(executed["data"]["child"]["pastEvents"]["edges"]) == 3
+    assert len(executed["data"]["child"]["pastEvents"]["edges"]) == 2
     snapshot.assert_match(executed)

--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -52,6 +52,11 @@ def guardian_api_client():
 
 @pytest.fixture
 def event():
+    return EventFactory(published_at=timezone.now())
+
+
+@pytest.fixture
+def unpublished_event():
     return EventFactory()
 
 
@@ -62,7 +67,9 @@ def venue():
 
 @pytest.fixture
 def occurrence():
-    return OccurrenceFactory(time=timezone.now())
+    return OccurrenceFactory(
+        time=timezone.now(), event=EventFactory(published_at=timezone.now())
+    )
 
 
 def _create_api_client_with_user(user):

--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -72,6 +72,11 @@ def occurrence():
     )
 
 
+@pytest.fixture
+def unpublished_occurrence():
+    return OccurrenceFactory(time=timezone.now(), event=EventFactory())
+
+
 def _create_api_client_with_user(user):
     request = RequestFactory().post("/graphql")
     request.user = user

--- a/events/schema.py
+++ b/events/schema.py
@@ -56,7 +56,11 @@ class EventNode(DjangoObjectType):
     # TODO: For now only logged in users can see events
     def get_queryset(cls, queryset, info):
         lang = get_language()
-        return queryset.order_by("-created_at").language(lang)
+        return (
+            queryset.user_can_view(info.context.user)
+            .order_by("-created_at")
+            .language(lang)
+        )
 
     @classmethod
     @login_required
@@ -85,9 +89,11 @@ class OccurrenceNode(DjangoObjectType):
     @classmethod
     @login_required
     def get_queryset(cls, queryset, info):
-        return queryset.annotate(
-            enrolments_count=Count("enrolments", distinct=True)
-        ).order_by("time")
+        return (
+            queryset.user_can_view(info.context.user)
+            .annotate(enrolments_count=Count("enrolments", distinct=True))
+            .order_by("time")
+        )
 
     @classmethod
     @login_required

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -81,7 +81,7 @@ snapshots["test_occurrence_query_normal_user 1"] = {
                 "duration": 197,
                 "image": "http://testserver/media/spring.jpg",
                 "participantsPerInvite": "FAMILY",
-                "publishedAt": None,
+                "publishedAt": "2020-12-12T00:00:00+00:00",
                 "translations": [
                     {
                         "description": """Serious listen police shake. Page box child care any concern.
@@ -170,7 +170,7 @@ snapshots["test_occurrence_available_capacity 1"] = {
                 "duration": 197,
                 "image": "http://testserver/media/spring.jpg",
                 "participantsPerInvite": "FAMILY",
-                "publishedAt": None,
+                "publishedAt": "2020-12-12T00:00:00+00:00",
                 "translations": [
                     {
                         "description": """Serious listen police shake. Page box child care any concern.
@@ -213,7 +213,7 @@ snapshots["test_enrolment_visibility 1"] = {
                 "duration": 255,
                 "image": "http://testserver/media/parent.jpg",
                 "participantsPerInvite": "FAMILY",
-                "publishedAt": None,
+                "publishedAt": "2020-12-12T00:00:00+00:00",
                 "translations": [
                     {
                         "description": """Glass person along age else. Skill down subject town range north skin.
@@ -280,7 +280,7 @@ Agree room laugh prevent make. Our very television beat at success decade.""",
                             ]
                         },
                         "participantsPerInvite": "FAMILY",
-                        "publishedAt": None,
+                        "publishedAt": "2020-12-12T00:00:00+00:00",
                         "shortDescription": "Perform in weight success answer.",
                         "translations": [
                             {
@@ -329,7 +329,7 @@ Agree room laugh prevent make. Our very television beat at success decade.""",
                 ]
             },
             "participantsPerInvite": "FAMILY",
-            "publishedAt": None,
+            "publishedAt": "2020-12-12T00:00:00+00:00",
             "shortDescription": "Perform in weight success answer.",
             "translations": [
                 {
@@ -356,7 +356,7 @@ snapshots["test_occurrences_query_normal_user 1"] = {
                             "duration": 197,
                             "image": "http://testserver/media/spring.jpg",
                             "participantsPerInvite": "FAMILY",
-                            "publishedAt": None,
+                            "publishedAt": "2020-12-12T00:00:00+00:00",
                             "translations": [
                                 {
                                     "description": """Serious listen police shake. Page box child care any concern.

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -404,13 +404,196 @@ snapshots["test_occurrences_filter_by_upcoming 1"] = {
     }
 }
 
+snapshots["test_events_query_staff_user 1"] = {
+    "data": {
+        "events": {
+            "edges": [
+                {
+                    "node": {
+                        "capacityPerOccurrence": 805,
+                        "createdAt": "2020-12-12T00:00:00+00:00",
+                        "description": """Serious listen police shake. Page box child care any concern.
+Agree room laugh prevent make. Our very television beat at success decade.""",
+                        "duration": 197,
+                        "image": "http://testserver/media/spring.jpg",
+                        "name": "Free heart significant machine try.",
+                        "occurrences": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "remainingCapacity": 805,
+                                        "time": "2009-07-12T04:07:58+00:00",
+                                        "venue": {
+                                            "translations": [
+                                                {
+                                                    "description": "Training thought price. Effort clear and local challenge box. Care figure mention wrong when lead involve.",
+                                                    "languageCode": "FI",
+                                                    "name": "Thank realize staff staff read.",
+                                                }
+                                            ]
+                                        },
+                                    }
+                                }
+                            ]
+                        },
+                        "participantsPerInvite": "FAMILY",
+                        "publishedAt": "2020-12-12T00:00:00+00:00",
+                        "shortDescription": "Perform in weight success answer.",
+                        "translations": [
+                            {
+                                "description": """Serious listen police shake. Page box child care any concern.
+Agree room laugh prevent make. Our very television beat at success decade.""",
+                                "languageCode": "FI",
+                                "name": "Free heart significant machine try.",
+                                "shortDescription": "Perform in weight success answer.",
+                            }
+                        ],
+                        "updatedAt": "2020-12-12T00:00:00+00:00",
+                    }
+                },
+                {
+                    "node": {
+                        "capacityPerOccurrence": 457,
+                        "createdAt": "2020-12-12T00:00:00+00:00",
+                        "description": """Wonder everything pay parent theory go home. Book and interesting sit future dream party. Truth list pressure stage history.
+If his their best. Election stay every something base.""",
+                        "duration": 42,
+                        "image": "http://testserver/media/think.jpg",
+                        "name": "Able process base sing according.",
+                        "occurrences": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "remainingCapacity": 457,
+                                        "time": "2019-11-11T17:08:21+00:00",
+                                        "venue": {
+                                            "translations": [
+                                                {
+                                                    "description": """Along hear follow sometimes. Special far magazine. Know say former conference carry factor front Mr.
+Conference thing much like test.""",
+                                                    "languageCode": "FI",
+                                                    "name": "Hand human value base pattern democratic focus.",
+                                                }
+                                            ]
+                                        },
+                                    }
+                                }
+                            ]
+                        },
+                        "participantsPerInvite": "FAMILY",
+                        "publishedAt": None,
+                        "shortDescription": "Later evening southern would according strong.",
+                        "translations": [
+                            {
+                                "description": """Wonder everything pay parent theory go home. Book and interesting sit future dream party. Truth list pressure stage history.
+If his their best. Election stay every something base.""",
+                                "languageCode": "FI",
+                                "name": "Able process base sing according.",
+                                "shortDescription": "Later evening southern would according strong.",
+                            }
+                        ],
+                        "updatedAt": "2020-12-12T00:00:00+00:00",
+                    }
+                },
+            ]
+        }
+    }
+}
+
+snapshots["test_occurrences_query_staff_user 1"] = {
+    "data": {
+        "occurrences": {
+            "edges": [
+                {
+                    "node": {
+                        "event": {
+                            "capacityPerOccurrence": 805,
+                            "duration": 197,
+                            "image": "http://testserver/media/spring.jpg",
+                            "participantsPerInvite": "FAMILY",
+                            "publishedAt": "2020-12-12T00:00:00+00:00",
+                            "translations": [
+                                {
+                                    "description": """Serious listen police shake. Page box child care any concern.
+Agree room laugh prevent make. Our very television beat at success decade.""",
+                                    "languageCode": "FI",
+                                    "name": "Free heart significant machine try.",
+                                    "shortDescription": "Perform in weight success answer.",
+                                }
+                            ],
+                        },
+                        "remainingCapacity": 805,
+                        "time": "2020-12-12T00:00:00+00:00",
+                        "venue": {
+                            "translations": [
+                                {
+                                    "accessibilityInfo": "Enjoy office water those notice medical. Already name likely behind mission network. Think significant land especially can quite.",
+                                    "additionalInfo": """Prevent pressure point. Voice radio happen color scene.
+Assume training seek full several. Authority develop identify ready.""",
+                                    "address": """1449 Hill Squares
+South Zacharyborough, CO 33337""",
+                                    "arrivalInstructions": """Last appear experience seven. Throw wrong party wall agency customer clear. Control as receive cup.
+Family around year off. Sense person the probably.""",
+                                    "description": "Later evening southern would according strong. Analysis season project executive entire.",
+                                    "languageCode": "FI",
+                                    "name": "Able process base sing according.",
+                                    "wwwUrl": "http://brooks.org/",
+                                }
+                            ]
+                        },
+                    }
+                },
+                {
+                    "node": {
+                        "event": {
+                            "capacityPerOccurrence": 700,
+                            "duration": 112,
+                            "image": "http://testserver/media/send.jpg",
+                            "participantsPerInvite": "CHILD_AND_GUARDIAN",
+                            "publishedAt": None,
+                            "translations": [
+                                {
+                                    "description": "Expert interview old affect quite nearly gun. Born land military first he law ago. Yard door indicate country individual course.",
+                                    "languageCode": "FI",
+                                    "name": "Up always sport return. Light a point charge stand store.",
+                                    "shortDescription": "East site chance of.",
+                                }
+                            ],
+                        },
+                        "remainingCapacity": 700,
+                        "time": "2020-12-12T00:00:00+00:00",
+                        "venue": {
+                            "translations": [
+                                {
+                                    "accessibilityInfo": """Court possible free anyone floor office eight do. Somebody determine sort under car medical.
+Word style also attention word join pay discuss. Performance part prevent explain.""",
+                                    "additionalInfo": """Offer organization model remember. Morning culture late oil sell.
+Tv news management letter. Animal list adult draw staff her.""",
+                                    "address": """663 Keith Ford Apt. 290
+Pruitthaven, DE 69289""",
+                                    "arrivalInstructions": """Large benefit occur eat discuss quickly buy. Decade address have turn serve me every traditional. Sound describe risk newspaper reflect four.
+Six feel real fast.""",
+                                    "description": "Run hand human value base. Include and individual effort indeed discuss challenge school. Book significant minute rest two special.",
+                                    "languageCode": "FI",
+                                    "name": "Huge realize at rather that place against moment.",
+                                    "wwwUrl": "https://brown-calhoun.org/",
+                                }
+                            ]
+                        },
+                    }
+                },
+            ]
+        }
+    }
+}
+
 snapshots["test_occurrences_filter_by_venue 1"] = {
     "data": {
         "occurrences": {
             "edges": [
-                {"node": {"time": "1979-09-06T12:02:19+00:00"}},
-                {"node": {"time": "2016-07-22T13:33:38+00:00"}},
-                {"node": {"time": "2019-04-01T18:42:35+00:00"}},
+                {"node": {"time": "1989-08-24T14:55:15+00:00"}},
+                {"node": {"time": "1990-07-20T12:20:16+00:00"}},
+                {"node": {"time": "2017-10-23T18:50:24+00:00"}},
             ]
         }
     }

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -603,10 +603,10 @@ def test_upload_image_to_event(staff_api_client, snapshot):
     assert event.image
 
 
-def test_staff_publish_event(snapshot, staff_api_client, event):
-    assert not event.is_published()
+def test_staff_publish_event(snapshot, staff_api_client, unpublished_event):
+    assert not unpublished_event.is_published()
     event_variables = deepcopy(PUBLISH_EVENT_VARIABLES)
-    event_variables["input"]["id"] = to_global_id("EventNode", event.id)
+    event_variables["input"]["id"] = to_global_id("EventNode", unpublished_event.id)
     executed = staff_api_client.execute(
         PUBLISH_EVENT_MUTATION, variables=event_variables
     )
@@ -769,28 +769,38 @@ def test_normal_translation_fields(snapshot, user_api_client, event):
         assert executed["data"]["event"]["name"] == translation
 
 
-def test_occurrences_filter_by_date(user_api_client, snapshot):
-    OccurrenceFactory(time=datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.now().tzinfo))
-    OccurrenceFactory(time=datetime(1970, 1, 2, 0, 0, 0, tzinfo=timezone.now().tzinfo))
+def test_occurrences_filter_by_date(user_api_client, snapshot, event):
+    OccurrenceFactory(
+        time=datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.now().tzinfo), event=event
+    )
+    OccurrenceFactory(
+        time=datetime(1970, 1, 2, 0, 0, 0, tzinfo=timezone.now().tzinfo), event=event
+    )
     variables = {"date": "1970-01-02"}
     executed = user_api_client.execute(OCCURRENCES_FILTER_QUERY, variables=variables)
 
     assert len(executed["data"]["occurrences"]["edges"]) == 1
-    OccurrenceFactory(time=datetime(1970, 1, 2, 0, 0, 0, tzinfo=timezone.now().tzinfo))
+    OccurrenceFactory(
+        time=datetime(1970, 1, 2, 0, 0, 0, tzinfo=timezone.now().tzinfo), event=event
+    )
     executed = user_api_client.execute(OCCURRENCES_FILTER_QUERY, variables=variables)
     assert len(executed["data"]["occurrences"]["edges"]) == 2
     snapshot.assert_match(executed)
 
 
-def test_occurrences_filter_by_time(user_api_client, snapshot):
+def test_occurrences_filter_by_time(user_api_client, snapshot, event):
     for i in range(10, 12):
         OccurrenceFactory(
-            time=datetime(1970, 1, 1, i, 0, 0, tzinfo=timezone.now().tzinfo)
+            time=datetime(1970, 1, 1, i, 0, 0, tzinfo=timezone.now().tzinfo),
+            event=event,
         )
         OccurrenceFactory(
-            time=datetime(1970, 1, 2, i + 1, 0, 0, tzinfo=timezone.now().tzinfo)
+            time=datetime(1970, 1, 2, i + 1, 0, 0, tzinfo=timezone.now().tzinfo),
+            event=event,
         )
-    OccurrenceFactory(time=datetime(1970, 1, 1, 13, 0, 0, tzinfo=timezone.now().tzinfo))
+    OccurrenceFactory(
+        time=datetime(1970, 1, 1, 13, 0, 0, tzinfo=timezone.now().tzinfo), event=event
+    )
     variables_1 = {"time": "12:00:00"}
     variables_2 = {"time": "14:00:00+02:00"}
     variables_3 = {"time": "11:00:00+00:00"}
@@ -804,9 +814,11 @@ def test_occurrences_filter_by_time(user_api_client, snapshot):
     snapshot.assert_match(executed)
 
 
-def test_occurrences_filter_by_upcoming(user_api_client, snapshot):
-    OccurrenceFactory(time=datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.now().tzinfo))
-    OccurrenceFactory(time=timezone.now())
+def test_occurrences_filter_by_upcoming(user_api_client, snapshot, event):
+    OccurrenceFactory(
+        time=datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.now().tzinfo), event=event
+    )
+    OccurrenceFactory(time=timezone.now(), event=event)
     variables = {"upcoming": True}
 
     executed = user_api_client.execute(OCCURRENCES_FILTER_QUERY, variables=variables)

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -392,6 +392,14 @@ def test_events_query_normal_user(snapshot, user_api_client, event):
     snapshot.assert_match(executed)
 
 
+def test_events_query_staff_user(snapshot, staff_api_client, event, unpublished_event):
+    OccurrenceFactory(event=event)
+    OccurrenceFactory(event=unpublished_event)
+    executed = staff_api_client.execute(EVENTS_QUERY)
+
+    snapshot.assert_match(executed)
+
+
 def test_event_query_unauthenticated(api_client, event):
     variables = {"id": to_global_id("EventNode", event.id)}
     executed = api_client.execute(EVENT_QUERY, variables=variables)
@@ -413,8 +421,18 @@ def test_occurrences_query_unauthenticated(api_client):
     assert_permission_denied(executed)
 
 
-def test_occurrences_query_normal_user(snapshot, user_api_client, occurrence):
+def test_occurrences_query_normal_user(
+    snapshot, user_api_client, occurrence, unpublished_occurrence
+):
     executed = user_api_client.execute(OCCURRENCES_QUERY)
+
+    snapshot.assert_match(executed)
+
+
+def test_occurrences_query_staff_user(
+    snapshot, staff_api_client, occurrence, unpublished_occurrence
+):
+    executed = staff_api_client.execute(OCCURRENCES_QUERY)
 
     snapshot.assert_match(executed)
 
@@ -830,9 +848,11 @@ def test_occurrences_filter_by_upcoming(user_api_client, snapshot, event):
     snapshot.assert_match(executed)
 
 
-def test_occurrences_filter_by_venue(user_api_client, snapshot):
-    occurrences = OccurrenceFactory.create_batch(2, venue=VenueFactory())
-    another_occurrences = OccurrenceFactory.create_batch(3, venue=VenueFactory())
+def test_occurrences_filter_by_venue(user_api_client, snapshot, event):
+    occurrences = OccurrenceFactory.create_batch(2, venue=VenueFactory(), event=event)
+    another_occurrences = OccurrenceFactory.create_batch(
+        3, venue=VenueFactory(), event=event
+    )
 
     variables = {"venueId": to_global_id("VenueNode", occurrences[0].venue.id)}
     executed = user_api_client.execute(OCCURRENCES_FILTER_QUERY, variables=variables)

--- a/events/tests/test_notifications.py
+++ b/events/tests/test_notifications.py
@@ -60,12 +60,15 @@ def notification_template_occurrence_unenrolment_fi():
 
 @pytest.mark.django_db
 def test_event_publish_notification(
-    snapshot, staff_api_client, notification_template_event_published_fi, event
+    snapshot,
+    staff_api_client,
+    notification_template_event_published_fi,
+    unpublished_event,
 ):
     GuardianFactory(language="fi")
     children = ChildWithGuardianFactory.create_batch(3)
     event_variables = deepcopy(PUBLISH_EVENT_VARIABLES)
-    event_variables["input"]["id"] = to_global_id("EventNode", event.id)
+    event_variables["input"]["id"] = to_global_id("EventNode", unpublished_event.id)
     staff_api_client.execute(PUBLISH_EVENT_MUTATION, variables=event_variables)
     assert len(mail.outbox) == len(children)
 

--- a/venues/tests/snapshots/snap_test_api.py
+++ b/venues/tests/snapshots/snap_test_api.py
@@ -20,32 +20,7 @@ Whiteview, TN 11309""",
                         "description": """Perform in weight success answer. Hospital number lose least then. Beyond than trial western.
 Page box child care any concern. Defense level church use.""",
                         "name": "Free heart significant machine try.",
-                        "occurrences": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "event": {
-                                            "capacityPerOccurrence": 712,
-                                            "duration": 300,
-                                            "image": "http://testserver/media/hand.jpg",
-                                            "participantsPerInvite": "CHILD_AND_GUARDIAN",
-                                            "publishedAt": None,
-                                            "translations": [
-                                                {
-                                                    "description": """Leg simple various be various. College able physical almost. Audience actually send address attorney candidate. Rock tough plant traditional.
-Build natural middle however.""",
-                                                    "languageCode": "EN",
-                                                    "name": "Think turn argue present. Spend prevent pressure point exist.",
-                                                    "shortDescription": "Others not authority develop identify ready.",
-                                                }
-                                            ],
-                                        },
-                                        "remainingCapacity": 712,
-                                        "time": "1984-07-02T07:57:10+00:00",
-                                    }
-                                }
-                            ]
-                        },
+                        "occurrences": {"edges": []},
                         "translations": [
                             {
                                 "accessibilityInfo": "From daughter order stay sign discover eight. Toward scientist service wonder everything. Middle moment strong hand push book and interesting.",
@@ -79,32 +54,7 @@ Whiteview, TN 11309""",
             "description": """Perform in weight success answer. Hospital number lose least then. Beyond than trial western.
 Page box child care any concern. Defense level church use.""",
             "name": "Free heart significant machine try.",
-            "occurrences": {
-                "edges": [
-                    {
-                        "node": {
-                            "event": {
-                                "capacityPerOccurrence": 712,
-                                "duration": 300,
-                                "image": "http://testserver/media/hand.jpg",
-                                "participantsPerInvite": "CHILD_AND_GUARDIAN",
-                                "publishedAt": None,
-                                "translations": [
-                                    {
-                                        "description": """Leg simple various be various. College able physical almost. Audience actually send address attorney candidate. Rock tough plant traditional.
-Build natural middle however.""",
-                                        "languageCode": "EN",
-                                        "name": "Think turn argue present. Spend prevent pressure point exist.",
-                                        "shortDescription": "Others not authority develop identify ready.",
-                                    }
-                                ],
-                            },
-                            "remainingCapacity": 712,
-                            "time": "1984-07-02T07:57:10+00:00",
-                        }
-                    }
-                ]
-            },
+            "occurrences": {"edges": []},
             "translations": [
                 {
                     "accessibilityInfo": "From daughter order stay sign discover eight. Toward scientist service wonder everything. Middle moment strong hand push book and interesting.",

--- a/venues/tests/test_api.py
+++ b/venues/tests/test_api.py
@@ -4,7 +4,6 @@ import pytest
 from graphql_relay import to_global_id
 
 from common.tests.utils import assert_permission_denied
-from events.factories import OccurrenceFactory
 from venues.models import Venue
 
 
@@ -196,7 +195,6 @@ def test_venues_query_unauthenticated(api_client):
 
 
 def test_venues_query_normal_user(snapshot, user_api_client, venue):
-    OccurrenceFactory(venue=venue)
     executed = user_api_client.execute(VENUES_QUERY)
 
     snapshot.assert_match(executed)
@@ -210,7 +208,6 @@ def test_venue_query_unauthenticated(api_client, venue):
 
 
 def test_venue_query_normal_user(snapshot, user_api_client, venue):
-    OccurrenceFactory(venue=venue)
     variables = {"id": to_global_id("VenueNode", venue.id)}
     executed = user_api_client.execute(VENUE_QUERY, variables=variables)
 


### PR DESCRIPTION
- Only staff user can query unpublished events (published_at=null) and occurrences of published event
    - Added queryset to filter events based on user
    - Added tests 
- Minor fix to `pastEvents` to return events which has no upcoming occurrences