### PR TITLE
Add make media directory to entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,9 @@ set -e
 service cron start
 su - appuser
 
+# Create folder to store media files
+mkdir -p /app/var/media
+
 export > /.env
 if [ -z "$SKIP_DATABASE_CHECK" -o "$SKIP_DATABASE_CHECK" = "0" ]; then
   until nc -z -v -w30 "$DATABASE_HOST" 5432


### PR DESCRIPTION
Related to #69 
In `.prod/uwsgi.ini`, there is a static-map to map media folder from `/media` to `/app/var/media` but it wouldn't work if the `/app/var/media` doesn't exist before starting uwsgi. Added a `mkdir` in docker entrypoint to make sure the folder exists before mapping.