### PR TITLE
Revert CDN config in staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,3 @@ staging:
     K8S_SECRET_MAIL_MAILGUN_API: "https://api.eu.mailgun.net/v3"
     K8S_SECRET_MAILER_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
     K8S_SECRET_DEFAULT_FROM_EMAIL: "no-reply@hel.ninja"
-    K8S_SECRET_DEFAULT_FILE_STORAGE: "storages.backends.gcloud.GoogleCloudStorage"
-    K8S_SECRET_GS_BUCKET_NAME: "$STORAGE_BUCKET_STAGING_NAME"
-    K8S_FILE_SECRET_GOOGLE_APPLICATION_CREDENTIALS: "$STORAGE_BUCKET_STAGING_CREDENTIALS"


### PR DESCRIPTION
https://gitlab.com/gitlab-org/gitlab/-/issues/29407
This bug make the file env var in gitlab returns file content instead of file path, which breaks the Google Cloud Storage setting in QA env. Temporary disabled CDN until there is a fix for it