### PR TITLE
KK-367 | Add translation validation

### DIFF
--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -613,3 +613,27 @@ snapshots["test_occurrences_filter_by_venue 1"] = {
         }
     }
 }
+
+snapshots["test_required_translation 1"] = {
+    "data": {
+        "addEvent": {
+            "event": {
+                "capacityPerOccurrence": 30,
+                "duration": 1000,
+                "image": "",
+                "imageAltText": "Image alt text",
+                "participantsPerInvite": "FAMILY",
+                "publishedAt": None,
+                "translations": [
+                    {
+                        "description": "desc",
+                        "imageAltText": "Image alt text",
+                        "languageCode": "FI",
+                        "name": "Event test",
+                        "shortDescription": "Short desc",
+                    }
+                ],
+            }
+        }
+    }
+}


### PR DESCRIPTION
so far I couldn't find any extra validation needed in events/occurrences/venue. So I only added validation for translation objects that requires default translation (defined by settings.LANGUAGE_CODE).

Note that backend only care about if the translation object is created, it doesn't care if all of the translation fields of that specific language are filled