### PR TITLE
KK-453 | Project API improvements

### DIFF
--- a/common/schema.py
+++ b/common/schema.py
@@ -1,0 +1,6 @@
+import graphene
+from django.conf import settings
+
+LanguageEnum = graphene.Enum(
+    "Language", [(l[0].upper(), l[0]) for l in settings.LANGUAGES]
+)

--- a/events/schema.py
+++ b/events/schema.py
@@ -14,6 +14,7 @@ from projects.models import Project
 
 from children.models import Child
 from children.schema import ChildNode
+from common.schema import LanguageEnum
 from common.utils import update_object, update_object_with_translations
 from events.filters import OccurrenceFilter
 from events.models import Enrolment, Event, Occurrence
@@ -25,7 +26,6 @@ from kukkuu.exceptions import (
     OccurrenceIsFullError,
     PastOccurrenceError,
 )
-from users.schema import LanguageEnum
 from venues.models import Venue
 
 EventTranslation = apps.get_model("events", "EventTranslation")

--- a/projects/schema.py
+++ b/projects/schema.py
@@ -24,6 +24,7 @@ class ProjectNode(DjangoObjectType):
     class Meta:
         model = Project
         interfaces = (relay.Node,)
+        exclude = ("users",)
 
     @classmethod
     @login_required

--- a/projects/schema.py
+++ b/projects/schema.py
@@ -5,7 +5,7 @@ from graphene_django import DjangoConnectionField, DjangoObjectType
 from graphql_jwt.decorators import login_required
 from projects.models import Project
 
-from users.schema import LanguageEnum
+from common.schema import LanguageEnum
 
 ProjectTranslation = apps.get_model("projects", "ProjectTranslation")
 

--- a/users/schema.py
+++ b/users/schema.py
@@ -1,5 +1,4 @@
 import graphene
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from graphene import relay
@@ -7,17 +6,13 @@ from graphene_django import DjangoConnectionField
 from graphene_django.types import DjangoObjectType
 from graphql_jwt.decorators import login_required
 
+from common.schema import LanguageEnum
 from common.utils import update_object
 from kukkuu.exceptions import ObjectDoesNotExistError
 
 from .models import Guardian
 
 User = get_user_model()
-
-
-LanguageEnum = graphene.Enum(
-    "Language", [(l[0].upper(), l[0]) for l in settings.LANGUAGES]
-)
 
 
 class GuardianNode(DjangoObjectType):

--- a/users/schema.py
+++ b/users/schema.py
@@ -32,16 +32,10 @@ class GuardianNode(DjangoObjectType):
 
 
 class AdminNode(DjangoObjectType):
-    is_project_admin = graphene.Boolean()
-
     class Meta:
         model = User
         interfaces = (relay.Node,)
-        fields = ("is_project_admin", "projects")
-
-    def resolve_is_project_admin(self, info, **kwargs):
-        # TODO: Update this when Project is available
-        return self.is_staff
+        fields = ("projects",)
 
 
 class UpdateMyProfileMutation(graphene.relay.ClientIDMutation):

--- a/users/schema.py
+++ b/users/schema.py
@@ -37,7 +37,7 @@ class AdminNode(DjangoObjectType):
     class Meta:
         model = User
         interfaces = (relay.Node,)
-        fields = ("is_project_admin",)
+        fields = ("is_project_admin", "projects")
 
     def resolve_is_project_admin(self, info, **kwargs):
         # TODO: Update this when Project is available

--- a/users/tests/snapshots/snap_test_api.py
+++ b/users/tests/snapshots/snap_test_api.py
@@ -134,12 +134,7 @@ snapshots["test_my_profile_query 1"] = {
 snapshots["test_my_admin_profile_project_admin 1"] = {
     "data": {
         "myAdminProfile": {
-            "isProjectAdmin": False,
-            "projects": {
-                "edges": [
-                    {"node": {"id": "UHJvamVjdE5vZGU6Mg==", "name": "my only project"}}
-                ]
-            },
+            "projects": {"edges": [{"node": {"name": "my only project"}}]}
         }
     }
 }

--- a/users/tests/snapshots/snap_test_api.py
+++ b/users/tests/snapshots/snap_test_api.py
@@ -130,3 +130,16 @@ snapshots["test_my_profile_query 1"] = {
         }
     }
 }
+
+snapshots["test_my_admin_profile_project_admin 1"] = {
+    "data": {
+        "myAdminProfile": {
+            "isProjectAdmin": False,
+            "projects": {
+                "edges": [
+                    {"node": {"id": "UHJvamVjdE5vZGU6Mg==", "name": "my only project"}}
+                ]
+            },
+        }
+    }
+}

--- a/users/tests/test_api.py
+++ b/users/tests/test_api.py
@@ -101,11 +101,9 @@ query MyProfile {
 MY_ADMIN_PROFILE_QUERY = """
 query MyAdminProfle{
   myAdminProfile{
-    isProjectAdmin
     projects {
       edges {
         node {
-          id
           name
         }
       }
@@ -192,13 +190,6 @@ def test_update_my_profile_mutation(snapshot, user_api_client):
 def test_my_admin_profile_unauthenticated(api_client):
     executed = api_client.execute(MY_ADMIN_PROFILE_QUERY)
     assert_permission_denied(executed)
-
-
-def test_my_admin_profile_authenticated(user_api_client, staff_api_client):
-    executed = user_api_client.execute(MY_ADMIN_PROFILE_QUERY)
-    assert not executed["data"]["myAdminProfile"]["isProjectAdmin"]
-    executed = staff_api_client.execute(MY_ADMIN_PROFILE_QUERY)
-    assert executed["data"]["myAdminProfile"]["isProjectAdmin"]
 
 
 def test_my_admin_profile_normal_user(user_api_client):


### PR DESCRIPTION
Added `projects` field to `MyAdminProfileNode` because Kukkuu admin UI needs info about current user's projects. After that the old field `is_project_admin` is a bit unnecessary, so removed that.

Also removed `users` from `ProjectNode` because it leaks information about users, and isn't needed for anything anyway.