### PR TITLE
KK-478 | Send email notification after guardian changed her email

### DIFF
--- a/users/__init__.py
+++ b/users/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "users.apps.UsersConfig"

--- a/users/apps.py
+++ b/users/apps.py
@@ -5,3 +5,6 @@ from django.utils.translation import ugettext_lazy as _
 class UsersConfig(AppConfig):
     name = "users"
     verbose_name = _("users")
+
+    def ready(self):
+        import users.notifications  # noqa

--- a/users/notifications.py
+++ b/users/notifications.py
@@ -1,0 +1,18 @@
+from django.utils.translation import ugettext_lazy as _
+from django_ilmoitin.dummy_context import dummy_context
+from django_ilmoitin.registry import notifications
+
+from .factories import GuardianFactory
+
+
+class NotificationType:
+    GUARDIAN_EMAIL_CHANGED = "guardian_email_changed"
+
+
+notifications.register(
+    NotificationType.GUARDIAN_EMAIL_CHANGED, _("Guardian email changed")
+)
+
+guardian = GuardianFactory.build()
+
+dummy_context.update({NotificationType.GUARDIAN_EMAIL_CHANGED: {"guardian": guardian}})

--- a/users/schema.py
+++ b/users/schema.py
@@ -13,6 +13,7 @@ from common.utils import update_object
 from kukkuu.exceptions import InvalidEmailFormatError, ObjectDoesNotExistError
 
 from .models import Guardian
+from .utils import send_guardian_email_changed_notification
 
 User = get_user_model()
 
@@ -67,7 +68,11 @@ class UpdateMyProfileMutation(graphene.relay.ClientIDMutation):
             raise ObjectDoesNotExistError(e)
 
         validate_guardian_data(kwargs)
+        old_email = guardian.email
         update_object(guardian, kwargs)
+
+        if guardian.email != old_email:
+            send_guardian_email_changed_notification(guardian)
 
         return UpdateMyProfileMutation(my_profile=guardian)
 

--- a/users/tests/snapshots/snap_test_notifications.py
+++ b/users/tests/snapshots/snap_test_notifications.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+snapshots = Snapshot()
+
+snapshots["test_guardian_changed_email_notification[new.email@example.com] 1"] = [
+    "kukkuu@example.com|['new.email@example.com']|Guardian email changed FI|Guardian FI: White Guardian"
+]
+
+snapshots["test_guardian_changed_email_notification[old.email@example.com] 1"] = []
+
+snapshots["test_guardian_changed_email_notification[None] 1"] = []

--- a/users/tests/test_notifications.py
+++ b/users/tests/test_notifications.py
@@ -1,0 +1,48 @@
+import pytest
+
+from common.tests.conftest import create_api_client_with_user
+from common.tests.utils import (
+    assert_mails_match_snapshot,
+    create_notification_template_in_language,
+)
+from users.factories import GuardianFactory
+from users.notifications import NotificationType
+
+
+@pytest.fixture
+def notification_template_guardian_email_changed_fi():
+    return create_notification_template_in_language(
+        NotificationType.GUARDIAN_EMAIL_CHANGED,
+        "fi",
+        subject="Guardian email changed FI",
+        body_text="Guardian FI: {{ guardian }}",
+    )
+
+
+@pytest.mark.parametrize(
+    "new_email", ("new.email@example.com", "old.email@example.com", None)
+)
+@pytest.mark.django_db
+def test_guardian_changed_email_notification(
+    snapshot, new_email, notification_template_guardian_email_changed_fi
+):
+    guardian = GuardianFactory(
+        first_name="Black", last_name="Guardian", email="old.email@example.com"
+    )
+    api_client = create_api_client_with_user(guardian.user)
+    params = {"email": new_email} if new_email else {}
+
+    api_client.execute(
+        """
+    mutation UpdateMyProfile($input: UpdateMyProfileMutationInput!) {
+      updateMyProfile(input: $input) {
+        myProfile {
+          email
+        }
+      }
+    }
+    """,
+        variables={"input": {"firstName": "White", **params}},
+    )
+
+    assert_mails_match_snapshot(snapshot)

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,0 +1,12 @@
+from django_ilmoitin.utils import send_notification
+
+from users.notifications import NotificationType
+
+
+def send_guardian_email_changed_notification(guardian):
+    send_notification(
+        guardian.email,
+        NotificationType.GUARDIAN_EMAIL_CHANGED,
+        context={"guardian": guardian},
+        language=guardian.language,
+    )


### PR DESCRIPTION
Added a new email notification which is sent after a guardian changes
her email address. The notification is sent to the new email address,
and only when the user has changed it herself, ie. the change comes
through UpdateMyProfileMutation.