### PR TITLE
KK-458 | Remove staff based permissions

### DIFF
--- a/children/models.py
+++ b/children/models.py
@@ -1,5 +1,6 @@
 from django.core.validators import RegexValidator
 from django.db import models
+from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 
 from common.models import TimestampedModel, UUIDPrimaryKeyModel
@@ -8,11 +9,7 @@ from users.models import Guardian
 
 class ChildQuerySet(models.QuerySet):
     def user_can_view(self, user):
-        # TODO we'll probably need more fine-grained control than this
-        if user.is_staff:
-            return self
-        else:
-            return self.filter(guardians__user=user)
+        return self.filter(Q(guardians__user=user) | Q(project__users=user)).distinct()
 
     def user_can_update(self, user):
         return self.filter(guardians__user=user)

--- a/children/models.py
+++ b/children/models.py
@@ -57,6 +57,13 @@ class Child(UUIDPrimaryKeyModel, TimestampedModel):
         return f"{self.first_name} {self.last_name} ({self.birthdate})"
 
 
+class RelationshipQuerySet(models.QuerySet):
+    def user_can_view(self, user):
+        return self.filter(
+            Q(guardian__user=user) | Q(child__project__users=user)
+        ).distinct()
+
+
 class Relationship(models.Model):
     PARENT = "parent"  # In Finnish: Vanhempi
     OTHER_GUARDIAN = "other_guardian"  # In Finnish: Muu huoltaja
@@ -89,6 +96,8 @@ class Relationship(models.Model):
         null=True,
         blank=True,
     )
+
+    objects = RelationshipQuerySet.as_manager()
 
     class Meta:
         verbose_name = _("relationship")

--- a/children/schema.py
+++ b/children/schema.py
@@ -85,6 +85,19 @@ class RelationshipNode(DjangoObjectType):
 
     type = graphene.Field(RelationshipTypeEnum)
 
+    @classmethod
+    @login_required
+    def get_queryset(cls, queryset, info):
+        return queryset.user_can_view(info.context.user).order_by("id")
+
+    @classmethod
+    @login_required
+    def get_node(cls, info, id):
+        try:
+            return cls._meta.model.objects.user_can_view(info.context.user).get(id=id)
+        except cls._meta.model.DoesNotExist:
+            return None
+
 
 class RelationshipInput(graphene.InputObjectType):
     type = RelationshipTypeEnum()

--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -6,120 +6,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["test_child_query 1"] = {
-    "data": {
-        "child": {
-            "birthdate": "2020-09-07",
-            "firstName": "John",
-            "lastName": "Terrell",
-            "postalCode": "77671",
-            "relationships": {
-                "edges": [
-                    {
-                        "node": {
-                            "guardian": {
-                                "email": "mperez@cox.com",
-                                "firstName": "Gregory",
-                                "lastName": "Cross",
-                                "phoneNumber": "750-649-7638x0346",
-                            },
-                            "type": "OTHER_GUARDIAN",
-                        }
-                    }
-                ]
-            },
-        }
-    }
-}
-
-snapshots["test_children_query_normal_user 1"] = {
-    "data": {
-        "children": {
-            "edges": [
-                {
-                    "node": {
-                        "birthdate": "2020-09-07",
-                        "firstName": "John",
-                        "lastName": "Terrell",
-                        "postalCode": "77671",
-                        "relationships": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "guardian": {
-                                            "email": "mperez@cox.com",
-                                            "firstName": "Gregory",
-                                            "lastName": "Cross",
-                                            "phoneNumber": "750-649-7638x0346",
-                                        },
-                                        "type": "OTHER_GUARDIAN",
-                                    }
-                                }
-                            ]
-                        },
-                    }
-                }
-            ]
-        }
-    }
-}
-
-snapshots["test_add_child_mutation 1"] = {
-    "data": {
-        "addChild": {
-            "child": {
-                "birthdate": "2020-11-11",
-                "firstName": "Pekka",
-                "lastName": "Perälä",
-                "postalCode": "00820",
-            }
-        }
-    }
-}
-
-snapshots["test_update_child_mutation 1"] = {
-    "data": {
-        "updateChild": {
-            "child": {
-                "birthdate": "2020-01-01",
-                "firstName": "Matti",
-                "lastName": "Mainio",
-                "postalCode": "00840",
-            }
-        }
-    }
-}
-
-snapshots["test_delete_child_mutation 1"] = {
-    "data": {"deleteChild": {"__typename": "DeleteChildMutationPayload"}}
-}
-
-snapshots["test_child_query_not_own_child_staff_user 1"] = {
-    "data": {
-        "child": {
-            "birthdate": "2020-09-07",
-            "firstName": "John",
-            "lastName": "Terrell",
-            "postalCode": "77671",
-            "relationships": {
-                "edges": [
-                    {
-                        "node": {
-                            "guardian": {
-                                "email": "kelly76@allen.com",
-                                "firstName": "Ashley",
-                                "lastName": "Castillo",
-                                "phoneNumber": "(117)159-1023x202",
-                            },
-                            "type": "OTHER_RELATION",
-                        }
-                    }
-                ]
-            },
-        }
-    }
-}
-
 snapshots["test_submit_children_and_guardian 1"] = {
     "data": {
         "submitChildrenAndGuardian": {
@@ -177,116 +63,6 @@ snapshots["test_submit_children_and_guardian 1"] = {
     }
 }
 
-snapshots["test_update_child_mutation_should_have_no_required_fields 1"] = {
-    "data": {
-        "updateChild": {
-            "child": {
-                "birthdate": "2020-09-05",
-                "firstName": "Katherine",
-                "lastName": "Wells",
-                "postalCode": "15910",
-            }
-        }
-    }
-}
-
-snapshots["test_children_query_staff_user 1"] = {
-    "data": {
-        "children": {
-            "edges": [
-                {
-                    "node": {
-                        "birthdate": "2020-03-01",
-                        "firstName": "Jason",
-                        "lastName": "Owens",
-                        "postalCode": "70898",
-                        "relationships": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "guardian": {
-                                            "email": "mperez@cox.com",
-                                            "firstName": "Selena",
-                                            "lastName": "Roy",
-                                            "phoneNumber": "123-447-4468",
-                                        },
-                                        "type": "OTHER_RELATION",
-                                    }
-                                }
-                            ]
-                        },
-                    }
-                },
-                {
-                    "node": {
-                        "birthdate": "2020-09-07",
-                        "firstName": "John",
-                        "lastName": "Terrell",
-                        "postalCode": "77671",
-                        "relationships": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "guardian": {
-                                            "email": "kelly76@allen.com",
-                                            "firstName": "Ashley",
-                                            "lastName": "Castillo",
-                                            "phoneNumber": "(117)159-1023x202",
-                                        },
-                                        "type": "OTHER_RELATION",
-                                    }
-                                }
-                            ]
-                        },
-                    }
-                },
-            ]
-        }
-    }
-}
-
-snapshots["test_get_available_events 1"] = {
-    "data": {
-        "child": {
-            "availableEvents": {
-                "edges": [
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 0}}]
-                            },
-                        }
-                    }
-                ]
-            },
-            "occurrences": {"edges": [{"node": {"time": "2020-12-12T00:00:00+00:00"}}]},
-            "pastEvents": {"edges": []},
-        }
-    }
-}
-
-snapshots["test_get_past_events 1"] = {
-    "data": {
-        "child": {
-            "availableEvents": {"edges": []},
-            "occurrences": {"edges": [{"node": {"time": "1969-12-31T22:20:00+00:00"}}]},
-            "pastEvents": {
-                "edges": [
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 0}}]
-                            },
-                        }
-                    }
-                ]
-            },
-        }
-    }
-}
-
 snapshots["test_submit_children_and_guardian_with_email 1"] = {
     "data": {
         "submitChildrenAndGuardian": {
@@ -339,6 +115,285 @@ snapshots["test_submit_children_and_guardian_with_email 1"] = {
                 "firstName": "Gulle",
                 "lastName": "Guardian",
                 "phoneNumber": "777-777777",
+            },
+        }
+    }
+}
+
+snapshots["test_children_query_normal_user 1"] = {
+    "data": {
+        "children": {
+            "edges": [
+                {
+                    "node": {
+                        "birthdate": "2020-09-07",
+                        "firstName": "John",
+                        "lastName": "Terrell",
+                        "postalCode": "77671",
+                        "relationships": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "guardian": {
+                                            "email": "mperez@cox.com",
+                                            "firstName": "Gregory",
+                                            "lastName": "Cross",
+                                            "phoneNumber": "750-649-7638x0346",
+                                        },
+                                        "type": "OTHER_GUARDIAN",
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots["test_children_query_project_user 1"] = {
+    "data": {
+        "children": {
+            "edges": [
+                {
+                    "node": {
+                        "birthdate": "2020-04-06",
+                        "firstName": "Same project",
+                        "lastName": "Should be returned 1/1",
+                        "postalCode": "57776",
+                        "relationships": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "guardian": {
+                                            "email": "rachelcruz@jenkins-crane.net",
+                                            "firstName": "Brandon",
+                                            "lastName": "Adams",
+                                            "phoneNumber": "727-011-7159x10232",
+                                        },
+                                        "type": "ADVOCATE",
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots["test_children_query_project_user_and_guardian 1"] = {
+    "data": {
+        "children": {
+            "edges": [
+                {
+                    "node": {
+                        "birthdate": "2020-08-29",
+                        "firstName": "Own child same project",
+                        "lastName": "Should be returned 1/3",
+                        "postalCode": "38034",
+                        "relationships": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "guardian": {
+                                            "email": "mperez@cox.com",
+                                            "firstName": "John",
+                                            "lastName": "Terrell",
+                                            "phoneNumber": "777.671.2406x75064",
+                                        },
+                                        "type": "OTHER_GUARDIAN",
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                },
+                {
+                    "node": {
+                        "birthdate": "2020-08-09",
+                        "firstName": "Own child another project",
+                        "lastName": "Should be returned 2/3",
+                        "postalCode": "27011",
+                        "relationships": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "guardian": {
+                                            "email": "mperez@cox.com",
+                                            "firstName": "John",
+                                            "lastName": "Terrell",
+                                            "phoneNumber": "777.671.2406x75064",
+                                        },
+                                        "type": "ADVOCATE",
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                },
+                {
+                    "node": {
+                        "birthdate": "2020-07-03",
+                        "firstName": "Not own child same project",
+                        "lastName": "Should be returned 3/3",
+                        "postalCode": "15910",
+                        "relationships": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "guardian": {
+                                            "email": "shawn70@hawkins-davis.com",
+                                            "firstName": "Alexis",
+                                            "lastName": "Santiago",
+                                            "phoneNumber": "(447)446-8581",
+                                        },
+                                        "type": "OTHER_GUARDIAN",
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                },
+            ]
+        }
+    }
+}
+
+snapshots["test_child_query 1"] = {
+    "data": {
+        "child": {
+            "birthdate": "2020-09-07",
+            "firstName": "John",
+            "lastName": "Terrell",
+            "postalCode": "77671",
+            "relationships": {
+                "edges": [
+                    {
+                        "node": {
+                            "guardian": {
+                                "email": "mperez@cox.com",
+                                "firstName": "Gregory",
+                                "lastName": "Cross",
+                                "phoneNumber": "750-649-7638x0346",
+                            },
+                            "type": "OTHER_GUARDIAN",
+                        }
+                    }
+                ]
+            },
+        }
+    }
+}
+
+snapshots["test_child_query_not_own_child_project_user 1"] = {
+    "data": {
+        "child": {
+            "birthdate": "2020-09-07",
+            "firstName": "John",
+            "lastName": "Terrell",
+            "postalCode": "77671",
+            "relationships": {
+                "edges": [
+                    {
+                        "node": {
+                            "guardian": {
+                                "email": "kelly76@allen.com",
+                                "firstName": "Ashley",
+                                "lastName": "Castillo",
+                                "phoneNumber": "(117)159-1023x202",
+                            },
+                            "type": "OTHER_RELATION",
+                        }
+                    }
+                ]
+            },
+        }
+    }
+}
+
+snapshots["test_add_child_mutation 1"] = {
+    "data": {
+        "addChild": {
+            "child": {
+                "birthdate": "2020-11-11",
+                "firstName": "Pekka",
+                "lastName": "Perälä",
+                "postalCode": "00820",
+            }
+        }
+    }
+}
+
+snapshots["test_update_child_mutation 1"] = {
+    "data": {
+        "updateChild": {
+            "child": {
+                "birthdate": "2020-01-01",
+                "firstName": "Matti",
+                "lastName": "Mainio",
+                "postalCode": "00840",
+            }
+        }
+    }
+}
+
+snapshots["test_update_child_mutation_should_have_no_required_fields 1"] = {
+    "data": {
+        "updateChild": {
+            "child": {
+                "birthdate": "2020-09-05",
+                "firstName": "Katherine",
+                "lastName": "Wells",
+                "postalCode": "15910",
+            }
+        }
+    }
+}
+
+snapshots["test_delete_child_mutation 1"] = {
+    "data": {"deleteChild": {"__typename": "DeleteChildMutationPayload"}}
+}
+
+snapshots["test_get_available_events 1"] = {
+    "data": {
+        "child": {
+            "availableEvents": {
+                "edges": [
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 0}}]
+                            },
+                        }
+                    }
+                ]
+            },
+            "occurrences": {"edges": [{"node": {"time": "2020-12-12T00:00:00+00:00"}}]},
+            "pastEvents": {"edges": []},
+        }
+    }
+}
+
+snapshots["test_get_past_events 1"] = {
+    "data": {
+        "child": {
+            "availableEvents": {"edges": []},
+            "occurrences": {"edges": [{"node": {"time": "1969-12-31T22:20:00+00:00"}}]},
+            "pastEvents": {
+                "edges": [
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [{"node": {"remainingCapacity": 0}}]
+                            },
+                        }
+                    }
+                ]
             },
         }
     }

--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -1,4 +1,5 @@
 import shutil
+from datetime import timedelta
 
 import factory.random
 import pytest
@@ -112,7 +113,9 @@ def occurrence(venue, event):
 
 @pytest.fixture
 def unpublished_occurrence(venue, unpublished_event):
-    return OccurrenceFactory(time=timezone.now(), venue=venue, event=unpublished_event)
+    return OccurrenceFactory(
+        time=timezone.now() + timedelta(hours=6), venue=venue, event=unpublished_event
+    )
 
 
 def create_api_client_with_user(user):

--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -63,11 +63,6 @@ def user_api_client():
 
 
 @pytest.fixture
-def staff_api_client():
-    return create_api_client_with_user(UserFactory(is_staff=True))
-
-
-@pytest.fixture
 def guardian_api_client():
     return create_api_client_with_user(UserFactory(guardian=GuardianFactory()))
 

--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -8,6 +8,7 @@ from django.test import RequestFactory
 from django.utils import timezone
 from freezegun import freeze_time
 from graphene.test import Client
+from projects.factories import ProjectFactory
 from projects.models import Project
 
 from children.factories import ChildWithGuardianFactory
@@ -41,6 +42,11 @@ def project():
 
 
 @pytest.fixture
+def another_project():
+    return ProjectFactory(year=2030, name="Toinen testiprojekti")
+
+
+@pytest.fixture
 def user():
     return UserFactory()
 
@@ -63,6 +69,13 @@ def staff_api_client():
 @pytest.fixture
 def guardian_api_client():
     return create_api_client_with_user(UserFactory(guardian=GuardianFactory()))
+
+
+@pytest.fixture()
+def project_user_api_client(project):
+    user = UserFactory()
+    user.projects.set([project])
+    return create_api_client_with_user(user)
 
 
 @pytest.fixture

--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -118,6 +118,22 @@ def unpublished_occurrence(venue, unpublished_event):
     )
 
 
+@pytest.fixture()
+def wrong_project_api_client(another_project):
+    user = UserFactory()
+    user.projects.set([another_project])
+    return create_api_client_with_user(user)
+
+
+@pytest.fixture(
+    params=range(3), ids=["unauthenticated_user", "normal_user", "wrong_project_user"]
+)
+def unauthorized_user_api_client(
+    api_client, user_api_client, wrong_project_api_client, request
+):
+    return (api_client, user_api_client, wrong_project_api_client)[request.param]
+
+
 def create_api_client_with_user(user):
     request = RequestFactory().post("/graphql")
     request.user = user

--- a/events/models.py
+++ b/events/models.py
@@ -86,9 +86,9 @@ class Event(TimestampedModel, TranslatableModel):
 
 class OccurrenceQueryset(models.QuerySet):
     def user_can_view(self, user):
-        if user.is_staff:
-            return self
-        return self.exclude(event__published_at=None)
+        return self.filter(
+            Q(event__project__users=user) | Q(event__published_at__isnull=False)
+        ).distinct()
 
 
 class Occurrence(TimestampedModel):

--- a/events/models.py
+++ b/events/models.py
@@ -70,6 +70,9 @@ class Event(TimestampedModel, TranslatableModel):
     def __str__(self):
         return self.safe_translation_getter("name", super().__str__())
 
+    def can_user_administer(self, user):
+        return user.projects.filter(pk=self.project_id).exists()
+
     def publish(self):
         self.published_at = timezone.now()
         self.save()
@@ -134,6 +137,11 @@ class Occurrence(TimestampedModel):
             return self.enrolment_count
         except AttributeError:
             return self.enrolments.count()
+
+    def can_user_administer(self, user):
+        # There shouldn't ever be a situation where event.project != venue.project
+        # so we can just check one of them
+        return user.projects.filter(pk=self.event.project.pk).exists()
 
 
 class Enrolment(models.Model):

--- a/events/models.py
+++ b/events/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db import models
+from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from parler.models import TranslatedFields
@@ -14,9 +15,9 @@ from venues.models import Venue
 # This need to be inherited from TranslatableQuerySet instead of default model.QuerySet
 class EventQueryset(TranslatableQuerySet):
     def user_can_view(self, user):
-        if user.is_staff:
-            return self
-        return self.exclude(published_at=None)
+        return self.filter(
+            Q(project__users=user) | Q(published_at__isnull=False)
+        ).distinct()
 
 
 class Event(TimestampedModel, TranslatableModel):

--- a/events/schema.py
+++ b/events/schema.py
@@ -8,14 +8,19 @@ from graphene import Connection, relay
 from graphene_django import DjangoConnectionField, DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 from graphene_file_upload.scalars import Upload
-from graphql_jwt.decorators import login_required, staff_member_required
+from graphql_jwt.decorators import login_required
 from graphql_relay import from_global_id
 from projects.models import Project
 
 from children.models import Child
 from children.schema import ChildNode
 from common.schema import LanguageEnum
-from common.utils import update_object, update_object_with_translations
+from common.utils import (
+    get_obj_if_user_can_administer,
+    project_user_required,
+    update_object,
+    update_object_with_translations,
+)
 from events.filters import OccurrenceFilter
 from events.models import Enrolment, Event, Occurrence
 from kukkuu.exceptions import (
@@ -164,16 +169,12 @@ class AddEventMutation(graphene.relay.ClientIDMutation):
     event = graphene.Field(EventNode)
 
     @classmethod
-    @staff_member_required
+    @project_user_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        # TODO: Add validation
-        project_global_id = kwargs.pop("project_id")
-        try:
-            project = Project.objects.get(pk=from_global_id(project_global_id)[1])
-            kwargs["project_id"] = project.id
-        except Project.DoesNotExist as e:
-            raise ObjectDoesNotExistError(e)
+        kwargs["project_id"] = get_obj_if_user_can_administer(
+            info, kwargs.pop("project_id"), Project
+        ).pk
         event = Event.objects.create_translatable_object(**kwargs)
         return AddEventMutation(event=event)
 
@@ -191,23 +192,17 @@ class UpdateEventMutation(graphene.relay.ClientIDMutation):
     event = graphene.Field(EventNode)
 
     @classmethod
-    @staff_member_required
+    @project_user_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        # TODO: Add validation
         project_global_id = kwargs.pop("project_id", None)
         if project_global_id:
-            try:
-                project = Project.objects.get(pk=from_global_id(project_global_id)[1])
-                kwargs["project_id"] = project.id
-            except Project.DoesNotExist as e:
-                raise ObjectDoesNotExistError(e)
-        event_global_id = kwargs.pop("id")
-        try:
-            event = Event.objects.get(pk=from_global_id(event_global_id)[1])
-            update_object_with_translations(event, kwargs)
-        except Event.DoesNotExist as e:
-            raise ObjectDoesNotExistError(e)
+            kwargs["project_id"] = get_obj_if_user_can_administer(
+                info, project_global_id, Project
+            ).pk
+
+        event = get_obj_if_user_can_administer(info, kwargs.pop("id"), Event)
+        update_object_with_translations(event, kwargs)
         return UpdateEventMutation(event=event)
 
 
@@ -216,16 +211,11 @@ class DeleteEventMutation(graphene.relay.ClientIDMutation):
         id = graphene.GlobalID()
 
     @classmethod
-    @staff_member_required
+    @project_user_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        # TODO: Validate data
-        event_id = from_global_id(kwargs["id"])[1]
-        try:
-            event = Event.objects.get(pk=event_id)
-            event.delete()
-        except Event.DoesNotExist as e:
-            raise ObjectDoesNotExistError(e)
+        event = get_obj_if_user_can_administer(info, kwargs["id"], Event)
+        event.delete()
         return DeleteEventMutation()
 
 
@@ -294,23 +284,15 @@ class AddOccurrenceMutation(graphene.relay.ClientIDMutation):
     occurrence = graphene.Field(OccurrenceNode)
 
     @classmethod
-    @staff_member_required
+    @project_user_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        # TODO: Validate data
-        event_id = from_global_id(kwargs["event_id"])[1]
-        try:
-            Event.objects.get(pk=event_id)
-            kwargs["event_id"] = event_id
-        except Event.DoesNotExist as e:
-            raise ObjectDoesNotExistError(e)
-
-        venue_id = from_global_id(kwargs["venue_id"])[1]
-        try:
-            Venue.objects.get(pk=venue_id)
-            kwargs["venue_id"] = venue_id
-        except Venue.DoesNotExist as e:
-            raise ObjectDoesNotExistError(e)
+        kwargs["event_id"] = get_obj_if_user_can_administer(
+            info, kwargs["event_id"], Event
+        ).pk
+        kwargs["venue_id"] = get_obj_if_user_can_administer(
+            info, kwargs["venue_id"], Venue
+        ).pk
 
         occurrence = Occurrence.objects.create(**kwargs)
 
@@ -331,32 +313,20 @@ class UpdateOccurrenceMutation(graphene.relay.ClientIDMutation):
     occurrence = graphene.Field(OccurrenceNode)
 
     @classmethod
-    @staff_member_required
+    @project_user_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        # TODO: Validate data
-        occurrence_id = from_global_id(kwargs["id"])[1]
-        try:
-            occurrence = Occurrence.objects.get(pk=occurrence_id)
-            kwargs["id"] = occurrence_id
-        except Occurrence.DoesNotExist as e:
-            raise ObjectDoesNotExistError(e)
+        occurrence = get_obj_if_user_can_administer(info, kwargs.pop("id"), Occurrence)
 
-        if kwargs.get("event_id", None):
-            event_id = from_global_id(kwargs["event_id"])[1]
-            try:
-                Event.objects.get(pk=event_id)
-                kwargs["event_id"] = event_id
-            except Event.DoesNotExist as e:
-                raise ObjectDoesNotExistError(e)
+        if kwargs.get("event_id"):
+            kwargs["event_id"] = get_obj_if_user_can_administer(
+                info, kwargs["event_id"], Event
+            ).pk
 
-        if kwargs.get("venue_id", None):
-            venue_id = from_global_id(kwargs["venue_id"])[1]
-            try:
-                Venue.objects.get(pk=venue_id)
-                kwargs["venue_id"] = venue_id
-            except Venue.DoesNotExist as e:
-                raise ObjectDoesNotExistError(e)
+        if kwargs.get("venue_id"):
+            kwargs["venue_id"] = get_obj_if_user_can_administer(
+                info, kwargs["venue_id"], Venue
+            ).pk
 
         update_object(occurrence, kwargs)
         return UpdateOccurrenceMutation(occurrence=occurrence)
@@ -367,16 +337,11 @@ class DeleteOccurrenceMutation(graphene.relay.ClientIDMutation):
         id = graphene.GlobalID()
 
     @classmethod
-    @staff_member_required
+    @project_user_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        # TODO: Validate data
-        occurrence_id = from_global_id(kwargs["id"])[1]
-        try:
-            occurrence = Occurrence.objects.get(pk=occurrence_id)
-            occurrence.delete()
-        except Occurrence.DoesNotExist as e:
-            raise ObjectDoesNotExistError(e)
+        occurrence = get_obj_if_user_can_administer(info, kwargs["id"], Occurrence)
+        occurrence.delete()
         return DeleteOccurrenceMutation()
 
 
@@ -387,19 +352,15 @@ class PublishEventMutation(graphene.relay.ClientIDMutation):
     event = graphene.Field(EventNode)
 
     @classmethod
-    @staff_member_required
+    @project_user_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        # TODO: Add validation
-        event_global_id = kwargs.pop("id")
-        try:
-            event = Event.objects.get(pk=from_global_id(event_global_id)[1])
-            if event.is_published():
-                raise EventAlreadyPublishedError("Event is already published")
-            event.publish()
+        event = get_obj_if_user_can_administer(info, kwargs["id"], Event)
 
-        except Event.DoesNotExist as e:
-            raise ObjectDoesNotExistError(e)
+        if event.is_published():
+            raise EventAlreadyPublishedError("Event is already published")
+
+        event.publish()
         return PublishEventMutation(event=event)
 
 

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -439,92 +439,6 @@ Page box child care any concern. Defense level church use.""",
     }
 }
 
-snapshots["test_occurrences_query_staff_user 1"] = {
-    "data": {
-        "occurrences": {
-            "edges": [
-                {
-                    "node": {
-                        "enrolmentCount": 0,
-                        "event": {
-                            "capacityPerOccurrence": 43,
-                            "duration": 112,
-                            "image": "http://testserver/media/send.jpg",
-                            "participantsPerInvite": "CHILD_AND_GUARDIAN",
-                            "publishedAt": "2020-12-12T00:00:00+00:00",
-                            "translations": [
-                                {
-                                    "description": "Expert interview old affect quite nearly gun. Born land military first he law ago. Yard door indicate country individual course.",
-                                    "languageCode": "FI",
-                                    "name": "Up always sport return. Light a point charge stand store.",
-                                    "shortDescription": "East site chance of.",
-                                }
-                            ],
-                        },
-                        "remainingCapacity": 43,
-                        "time": "2020-12-12T00:00:00+00:00",
-                        "venue": {
-                            "translations": [
-                                {
-                                    "accessibilityInfo": "From daughter order stay sign discover eight. Toward scientist service wonder everything. Middle moment strong hand push book and interesting.",
-                                    "additionalInfo": "Training thought price. Effort clear and local challenge box. Care figure mention wrong when lead involve.",
-                                    "address": """48830 Whitehead Rapid Suite 548
-Whiteview, TN 11309""",
-                                    "arrivalInstructions": "Benefit treat final central. Past ready join enjoy. Huge get this success commercial recently from.",
-                                    "description": """Perform in weight success answer. Hospital number lose least then. Beyond than trial western.
-Page box child care any concern. Defense level church use.""",
-                                    "languageCode": "FI",
-                                    "name": "Free heart significant machine try.",
-                                    "wwwUrl": "http://brooks.org/",
-                                }
-                            ]
-                        },
-                    }
-                },
-                {
-                    "node": {
-                        "enrolmentCount": 0,
-                        "event": {
-                            "capacityPerOccurrence": 26,
-                            "duration": 220,
-                            "image": "http://testserver/media/eight.jpg",
-                            "participantsPerInvite": "CHILD_AND_GUARDIAN",
-                            "publishedAt": None,
-                            "translations": [
-                                {
-                                    "description": """Along hear follow sometimes. Special far magazine. Know say former conference carry factor front Mr.
-Conference thing much like test.""",
-                                    "languageCode": "FI",
-                                    "name": "Huge realize at rather that place against moment.",
-                                    "shortDescription": "Run hand human value base.",
-                                }
-                            ],
-                        },
-                        "remainingCapacity": 26,
-                        "time": "2020-12-12T00:00:00+00:00",
-                        "venue": {
-                            "translations": [
-                                {
-                                    "accessibilityInfo": "From daughter order stay sign discover eight. Toward scientist service wonder everything. Middle moment strong hand push book and interesting.",
-                                    "additionalInfo": "Training thought price. Effort clear and local challenge box. Care figure mention wrong when lead involve.",
-                                    "address": """48830 Whitehead Rapid Suite 548
-Whiteview, TN 11309""",
-                                    "arrivalInstructions": "Benefit treat final central. Past ready join enjoy. Huge get this success commercial recently from.",
-                                    "description": """Perform in weight success answer. Hospital number lose least then. Beyond than trial western.
-Page box child care any concern. Defense level church use.""",
-                                    "languageCode": "FI",
-                                    "name": "Free heart significant machine try.",
-                                    "wwwUrl": "http://brooks.org/",
-                                }
-                            ]
-                        },
-                    }
-                },
-            ]
-        }
-    }
-}
-
 snapshots["test_child_enrol_occurence_from_different_project 1"] = {
     "data": {
         "enrolOccurrence": {
@@ -652,7 +566,26 @@ If his their best. Election stay every something base.""",
                         "image": "http://testserver/media/think.jpg",
                         "imageAltText": "",
                         "name": "Able process base sing according.",
-                        "occurrences": {"edges": []},
+                        "occurrences": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "enrolmentCount": 0,
+                                        "remainingCapacity": 28,
+                                        "time": "2012-05-15T10:30:47+00:00",
+                                        "venue": {
+                                            "translations": [
+                                                {
+                                                    "description": "Effort clear and local challenge box. Care figure mention wrong when lead involve. Event lay yes policy data control as receive. End available avoid girl middle.",
+                                                    "languageCode": "FI",
+                                                    "name": "Especially can quite industry relationship very produce social.",
+                                                }
+                                            ]
+                                        },
+                                    }
+                                }
+                            ]
+                        },
                         "participantsPerInvite": "FAMILY",
                         "project": {"year": 2020},
                         "publishedAt": None,
@@ -668,6 +601,92 @@ If his their best. Election stay every something base.""",
                             }
                         ],
                         "updatedAt": "2020-12-12T00:00:00+00:00",
+                    }
+                },
+            ]
+        }
+    }
+}
+
+snapshots["test_occurrences_query_project_user 1"] = {
+    "data": {
+        "occurrences": {
+            "edges": [
+                {
+                    "node": {
+                        "enrolmentCount": 0,
+                        "event": {
+                            "capacityPerOccurrence": 43,
+                            "duration": 112,
+                            "image": "http://testserver/media/send.jpg",
+                            "participantsPerInvite": "CHILD_AND_GUARDIAN",
+                            "publishedAt": "2020-12-12T00:00:00+00:00",
+                            "translations": [
+                                {
+                                    "description": "Expert interview old affect quite nearly gun. Born land military first he law ago. Yard door indicate country individual course.",
+                                    "languageCode": "FI",
+                                    "name": "Up always sport return. Light a point charge stand store.",
+                                    "shortDescription": "East site chance of.",
+                                }
+                            ],
+                        },
+                        "remainingCapacity": 43,
+                        "time": "2020-12-12T00:00:00+00:00",
+                        "venue": {
+                            "translations": [
+                                {
+                                    "accessibilityInfo": "From daughter order stay sign discover eight. Toward scientist service wonder everything. Middle moment strong hand push book and interesting.",
+                                    "additionalInfo": "Training thought price. Effort clear and local challenge box. Care figure mention wrong when lead involve.",
+                                    "address": """48830 Whitehead Rapid Suite 548
+Whiteview, TN 11309""",
+                                    "arrivalInstructions": "Benefit treat final central. Past ready join enjoy. Huge get this success commercial recently from.",
+                                    "description": """Perform in weight success answer. Hospital number lose least then. Beyond than trial western.
+Page box child care any concern. Defense level church use.""",
+                                    "languageCode": "FI",
+                                    "name": "Free heart significant machine try.",
+                                    "wwwUrl": "http://brooks.org/",
+                                }
+                            ]
+                        },
+                    }
+                },
+                {
+                    "node": {
+                        "enrolmentCount": 0,
+                        "event": {
+                            "capacityPerOccurrence": 26,
+                            "duration": 220,
+                            "image": "http://testserver/media/eight.jpg",
+                            "participantsPerInvite": "CHILD_AND_GUARDIAN",
+                            "publishedAt": None,
+                            "translations": [
+                                {
+                                    "description": """Along hear follow sometimes. Special far magazine. Know say former conference carry factor front Mr.
+Conference thing much like test.""",
+                                    "languageCode": "FI",
+                                    "name": "Huge realize at rather that place against moment.",
+                                    "shortDescription": "Run hand human value base.",
+                                }
+                            ],
+                        },
+                        "remainingCapacity": 26,
+                        "time": "2020-12-12T00:00:00+00:00",
+                        "venue": {
+                            "translations": [
+                                {
+                                    "accessibilityInfo": "From daughter order stay sign discover eight. Toward scientist service wonder everything. Middle moment strong hand push book and interesting.",
+                                    "additionalInfo": "Training thought price. Effort clear and local challenge box. Care figure mention wrong when lead involve.",
+                                    "address": """48830 Whitehead Rapid Suite 548
+Whiteview, TN 11309""",
+                                    "arrivalInstructions": "Benefit treat final central. Past ready join enjoy. Huge get this success commercial recently from.",
+                                    "description": """Perform in weight success answer. Hospital number lose least then. Beyond than trial western.
+Page box child care any concern. Defense level church use.""",
+                                    "languageCode": "FI",
+                                    "name": "Free heart significant machine try.",
+                                    "wwwUrl": "http://brooks.org/",
+                                }
+                            ]
+                        },
                     }
                 },
             ]

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -6,79 +6,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["test_add_event_staff_user 1"] = {
-    "data": {
-        "addEvent": {
-            "event": {
-                "capacityPerOccurrence": 30,
-                "duration": 1000,
-                "image": "",
-                "imageAltText": "Image alt text",
-                "participantsPerInvite": "FAMILY",
-                "project": {"year": 2020},
-                "publishedAt": None,
-                "translations": [
-                    {
-                        "description": "desc",
-                        "imageAltText": "Image alt text",
-                        "languageCode": "FI",
-                        "name": "Event test",
-                        "shortDescription": "Short desc",
-                    }
-                ],
-            }
-        }
-    }
-}
-
-snapshots["test_add_occurrence_staff_user 1"] = {
-    "data": {
-        "addOccurrence": {
-            "occurrence": {
-                "event": {"createdAt": "2020-12-12T00:00:00+00:00"},
-                "occurrenceLanguage": "FI",
-                "time": "1986-12-12T16:40:48+00:00",
-                "venue": {"createdAt": "2020-12-12T00:00:00+00:00"},
-            }
-        }
-    }
-}
-
-snapshots["test_update_event_staff_user 1"] = {
-    "data": {
-        "updateEvent": {
-            "event": {
-                "capacityPerOccurrence": 30,
-                "duration": 1000,
-                "image": "http://testserver/media/spring.jpg",
-                "imageAltText": "Image alt text",
-                "occurrences": {"edges": []},
-                "participantsPerInvite": "FAMILY",
-                "translations": [
-                    {
-                        "description": "desc",
-                        "imageAltText": "Image alt text",
-                        "languageCode": "SV",
-                        "name": "Event test in swedish",
-                        "shortDescription": "Short desc",
-                    },
-                    {
-                        "description": "desc",
-                        "imageAltText": "Image alt text",
-                        "languageCode": "FI",
-                        "name": "Event test in suomi",
-                        "shortDescription": "Short desc",
-                    },
-                ],
-            }
-        }
-    }
-}
-
-snapshots["test_staff_publish_event 1"] = {
-    "data": {"publishEvent": {"event": {"publishedAt": "2020-12-12T00:00:00+00:00"}}}
-}
-
 snapshots["test_occurrence_query_normal_user 1"] = {
     "data": {
         "occurrence": {
@@ -118,21 +45,6 @@ Page box child care any concern. Defense level church use.""",
                     }
                 ]
             },
-        }
-    }
-}
-
-snapshots["test_update_occurrence_staff_user 1"] = {
-    "data": {
-        "updateOccurrence": {
-            "occurrence": {
-                "enrolmentCount": 0,
-                "event": {"createdAt": "2020-12-12T00:00:00+00:00"},
-                "occurrenceLanguage": "SV",
-                "remainingCapacity": 43,
-                "time": "1986-12-12T16:40:48+00:00",
-                "venue": {"createdAt": "2020-12-12T00:00:00+00:00"},
-            }
         }
     }
 }
@@ -692,4 +604,92 @@ Page box child care any concern. Defense level church use.""",
             ]
         }
     }
+}
+
+snapshots["test_add_event_project_user 1"] = {
+    "data": {
+        "addEvent": {
+            "event": {
+                "capacityPerOccurrence": 30,
+                "duration": 1000,
+                "image": "",
+                "imageAltText": "Image alt text",
+                "participantsPerInvite": "FAMILY",
+                "project": {"year": 2020},
+                "publishedAt": None,
+                "translations": [
+                    {
+                        "description": "desc",
+                        "imageAltText": "Image alt text",
+                        "languageCode": "FI",
+                        "name": "Event test",
+                        "shortDescription": "Short desc",
+                    }
+                ],
+            }
+        }
+    }
+}
+
+snapshots["test_add_occurrence_project_user 1"] = {
+    "data": {
+        "addOccurrence": {
+            "occurrence": {
+                "event": {"createdAt": "2020-12-12T00:00:00+00:00"},
+                "occurrenceLanguage": "FI",
+                "time": "1986-12-12T16:40:48+00:00",
+                "venue": {"createdAt": "2020-12-12T00:00:00+00:00"},
+            }
+        }
+    }
+}
+
+snapshots["test_update_occurrence_project_user 1"] = {
+    "data": {
+        "updateOccurrence": {
+            "occurrence": {
+                "enrolmentCount": 0,
+                "event": {"createdAt": "2020-12-12T00:00:00+00:00"},
+                "occurrenceLanguage": "SV",
+                "remainingCapacity": 43,
+                "time": "1986-12-12T16:40:48+00:00",
+                "venue": {"createdAt": "2020-12-12T00:00:00+00:00"},
+            }
+        }
+    }
+}
+
+snapshots["test_update_event_project_user 1"] = {
+    "data": {
+        "updateEvent": {
+            "event": {
+                "capacityPerOccurrence": 30,
+                "duration": 1000,
+                "image": "http://testserver/media/spring.jpg",
+                "imageAltText": "Image alt text",
+                "occurrences": {"edges": []},
+                "participantsPerInvite": "FAMILY",
+                "translations": [
+                    {
+                        "description": "desc",
+                        "imageAltText": "Image alt text",
+                        "languageCode": "SV",
+                        "name": "Event test in swedish",
+                        "shortDescription": "Short desc",
+                    },
+                    {
+                        "description": "desc",
+                        "imageAltText": "Image alt text",
+                        "languageCode": "FI",
+                        "name": "Event test in suomi",
+                        "shortDescription": "Short desc",
+                    },
+                ],
+            }
+        }
+    }
+}
+
+snapshots["test_project_user_publish_event 1"] = {
+    "data": {"publishEvent": {"event": {"publishedAt": "2020-12-12T00:00:00+00:00"}}}
 }

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -290,109 +290,6 @@ Agree room laugh prevent make. Our very television beat at success decade.""",
     }
 }
 
-snapshots["test_events_query_staff_user 1"] = {
-    "data": {
-        "events": {
-            "edges": [
-                {
-                    "node": {
-                        "capacityPerOccurrence": 50,
-                        "createdAt": "2020-12-12T00:00:00+00:00",
-                        "description": """Serious listen police shake. Page box child care any concern.
-Agree room laugh prevent make. Our very television beat at success decade.""",
-                        "duration": 197,
-                        "image": "http://testserver/media/spring.jpg",
-                        "imageAltText": "",
-                        "name": "Free heart significant machine try.",
-                        "occurrences": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "enrolmentCount": 0,
-                                        "remainingCapacity": 50,
-                                        "time": "1978-11-27T17:53:39+00:00",
-                                        "venue": {
-                                            "translations": [
-                                                {
-                                                    "description": "Effort clear and local challenge box. Care figure mention wrong when lead involve. Event lay yes policy data control as receive. End available avoid girl middle.",
-                                                    "languageCode": "FI",
-                                                    "name": "Especially can quite industry relationship very produce social.",
-                                                }
-                                            ]
-                                        },
-                                    }
-                                }
-                            ]
-                        },
-                        "participantsPerInvite": "FAMILY",
-                        "project": {"year": 2020},
-                        "publishedAt": "2020-12-12T00:00:00+00:00",
-                        "shortDescription": "Perform in weight success answer.",
-                        "translations": [
-                            {
-                                "description": """Serious listen police shake. Page box child care any concern.
-Agree room laugh prevent make. Our very television beat at success decade.""",
-                                "imageAltText": "",
-                                "languageCode": "FI",
-                                "name": "Free heart significant machine try.",
-                                "shortDescription": "Perform in weight success answer.",
-                            }
-                        ],
-                        "updatedAt": "2020-12-12T00:00:00+00:00",
-                    }
-                },
-                {
-                    "node": {
-                        "capacityPerOccurrence": 28,
-                        "createdAt": "2020-12-12T00:00:00+00:00",
-                        "description": """Wonder everything pay parent theory go home. Book and interesting sit future dream party. Truth list pressure stage history.
-If his their best. Election stay every something base.""",
-                        "duration": 42,
-                        "image": "http://testserver/media/think.jpg",
-                        "imageAltText": "",
-                        "name": "Able process base sing according.",
-                        "occurrences": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "enrolmentCount": 0,
-                                        "remainingCapacity": 28,
-                                        "time": "2012-05-15T10:30:47+00:00",
-                                        "venue": {
-                                            "translations": [
-                                                {
-                                                    "description": "Effort clear and local challenge box. Care figure mention wrong when lead involve. Event lay yes policy data control as receive. End available avoid girl middle.",
-                                                    "languageCode": "FI",
-                                                    "name": "Especially can quite industry relationship very produce social.",
-                                                }
-                                            ]
-                                        },
-                                    }
-                                }
-                            ]
-                        },
-                        "participantsPerInvite": "FAMILY",
-                        "project": {"year": 2020},
-                        "publishedAt": None,
-                        "shortDescription": "Later evening southern would according strong.",
-                        "translations": [
-                            {
-                                "description": """Wonder everything pay parent theory go home. Book and interesting sit future dream party. Truth list pressure stage history.
-If his their best. Election stay every something base.""",
-                                "imageAltText": "",
-                                "languageCode": "FI",
-                                "name": "Able process base sing according.",
-                                "shortDescription": "Later evening southern would according strong.",
-                            }
-                        ],
-                        "updatedAt": "2020-12-12T00:00:00+00:00",
-                    }
-                },
-            ]
-        }
-    }
-}
-
 snapshots["test_unenrol_occurrence 1"] = {
     "data": {
         "unenrolOccurrence": {
@@ -690,6 +587,90 @@ Page box child care any concern. Defense level church use.""",
                     }
                 ]
             },
+        }
+    }
+}
+
+snapshots["test_events_query_project_user 1"] = {
+    "data": {
+        "events": {
+            "edges": [
+                {
+                    "node": {
+                        "capacityPerOccurrence": 50,
+                        "createdAt": "2020-12-12T00:00:00+00:00",
+                        "description": """Serious listen police shake. Page box child care any concern.
+Agree room laugh prevent make. Our very television beat at success decade.""",
+                        "duration": 197,
+                        "image": "http://testserver/media/spring.jpg",
+                        "imageAltText": "",
+                        "name": "Free heart significant machine try.",
+                        "occurrences": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "enrolmentCount": 0,
+                                        "remainingCapacity": 50,
+                                        "time": "1978-11-27T17:53:39+00:00",
+                                        "venue": {
+                                            "translations": [
+                                                {
+                                                    "description": "Effort clear and local challenge box. Care figure mention wrong when lead involve. Event lay yes policy data control as receive. End available avoid girl middle.",
+                                                    "languageCode": "FI",
+                                                    "name": "Especially can quite industry relationship very produce social.",
+                                                }
+                                            ]
+                                        },
+                                    }
+                                }
+                            ]
+                        },
+                        "participantsPerInvite": "FAMILY",
+                        "project": {"year": 2020},
+                        "publishedAt": "2020-12-12T00:00:00+00:00",
+                        "shortDescription": "Perform in weight success answer.",
+                        "translations": [
+                            {
+                                "description": """Serious listen police shake. Page box child care any concern.
+Agree room laugh prevent make. Our very television beat at success decade.""",
+                                "imageAltText": "",
+                                "languageCode": "FI",
+                                "name": "Free heart significant machine try.",
+                                "shortDescription": "Perform in weight success answer.",
+                            }
+                        ],
+                        "updatedAt": "2020-12-12T00:00:00+00:00",
+                    }
+                },
+                {
+                    "node": {
+                        "capacityPerOccurrence": 28,
+                        "createdAt": "2020-12-12T00:00:00+00:00",
+                        "description": """Wonder everything pay parent theory go home. Book and interesting sit future dream party. Truth list pressure stage history.
+If his their best. Election stay every something base.""",
+                        "duration": 42,
+                        "image": "http://testserver/media/think.jpg",
+                        "imageAltText": "",
+                        "name": "Able process base sing according.",
+                        "occurrences": {"edges": []},
+                        "participantsPerInvite": "FAMILY",
+                        "project": {"year": 2020},
+                        "publishedAt": None,
+                        "shortDescription": "Later evening southern would according strong.",
+                        "translations": [
+                            {
+                                "description": """Wonder everything pay parent theory go home. Book and interesting sit future dream party. Truth list pressure stage history.
+If his their best. Election stay every something base.""",
+                                "imageAltText": "",
+                                "languageCode": "FI",
+                                "name": "Able process base sing according.",
+                                "shortDescription": "Later evening southern would according strong.",
+                            }
+                        ],
+                        "updatedAt": "2020-12-12T00:00:00+00:00",
+                    }
+                },
+            ]
         }
     }
 }

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -670,7 +670,7 @@ Conference thing much like test.""",
                             ],
                         },
                         "remainingCapacity": 26,
-                        "time": "2020-12-12T00:00:00+00:00",
+                        "time": "2020-12-12T06:00:00+00:00",
                         "venue": {
                             "translations": [
                                 {

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -494,10 +494,10 @@ def test_occurrences_query_normal_user(
     snapshot.assert_match(executed)
 
 
-def test_occurrences_query_staff_user(
-    snapshot, staff_api_client, occurrence, unpublished_occurrence
+def test_occurrences_query_project_user(
+    snapshot, project_user_api_client, occurrence, unpublished_occurrence
 ):
-    executed = staff_api_client.execute(OCCURRENCES_QUERY)
+    executed = project_user_api_client.execute(OCCURRENCES_QUERY)
 
     snapshot.assert_match(executed)
 

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -452,12 +452,15 @@ def test_events_query_normal_user(snapshot, user_api_client, event, venue):
     snapshot.assert_match(executed)
 
 
-def test_events_query_staff_user(
-    snapshot, staff_api_client, event, unpublished_event, venue
+def test_events_query_project_user(
+    snapshot, project_user_api_client, event, unpublished_event, venue, another_project
 ):
     OccurrenceFactory(event=event, venue=venue)
     OccurrenceFactory(event=unpublished_event, venue=venue)
-    executed = staff_api_client.execute(EVENTS_QUERY)
+    # unpublished event from another project, should not be returned
+    OccurrenceFactory(event=EventFactory(project=another_project), venue=venue)
+
+    executed = project_user_api_client.execute(EVENTS_QUERY)
 
     snapshot.assert_match(executed)
 

--- a/events/tests/test_notifications.py
+++ b/events/tests/test_notifications.py
@@ -63,7 +63,7 @@ def notification_template_occurrence_unenrolment_fi():
 @pytest.mark.django_db
 def test_event_publish_notification(
     snapshot,
-    staff_api_client,
+    project_user_api_client,
     notification_template_event_published_fi,
     unpublished_event,
     project,
@@ -75,7 +75,7 @@ def test_event_publish_notification(
 
     event_variables = deepcopy(PUBLISH_EVENT_VARIABLES)
     event_variables["input"]["id"] = to_global_id("EventNode", unpublished_event.id)
-    staff_api_client.execute(PUBLISH_EVENT_MUTATION, variables=event_variables)
+    project_user_api_client.execute(PUBLISH_EVENT_MUTATION, variables=event_variables)
 
     assert len(mail.outbox) == 5  # 3 children of which one has 3 guardians
 

--- a/projects/models.py
+++ b/projects/models.py
@@ -20,3 +20,6 @@ class Project(TranslatableModel):
 
     def __str__(self):
         return f"#{self.pk} {self.year}"
+
+    def can_user_administer(self, user):
+        return user.projects.filter(pk=self.pk).exists()

--- a/users/models.py
+++ b/users/models.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
+from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 from helusers.models import AbstractUser
 
@@ -15,11 +16,7 @@ class User(AbstractUser):
 
 class GuardianQuerySet(models.QuerySet):
     def user_can_view(self, user):
-        # TODO we'll probably need more fine-grained control than this
-        if user.is_staff:
-            return self
-        else:
-            return self.filter(user=user)
+        return self.filter(Q(user=user) | Q(children__project__users=user)).distinct()
 
 
 class Guardian(UUIDPrimaryKeyModel, TimestampedModel):

--- a/users/tests/snapshots/snap_test_api.py
+++ b/users/tests/snapshots/snap_test_api.py
@@ -6,59 +6,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["test_guardians_query_staff_user 1"] = {
-    "data": {
-        "guardians": {
-            "edges": [
-                {
-                    "node": {
-                        "email": "ramirezandrew@burns.com",
-                        "firstName": "Christy",
-                        "lastName": "Jenkins",
-                        "phoneNumber": "001-803-466-9727x0117",
-                        "relationships": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "child": {
-                                            "birthdate": "2020-02-14",
-                                            "firstName": "Robin",
-                                            "lastName": "Moses",
-                                        },
-                                        "type": "ADVOCATE",
-                                    }
-                                }
-                            ]
-                        },
-                    }
-                },
-                {
-                    "node": {
-                        "email": "mperez@cox.com",
-                        "firstName": "Sandra",
-                        "lastName": "Meyer",
-                        "phoneNumber": "(727)708-9817",
-                        "relationships": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "child": {
-                                            "birthdate": "2020-11-22",
-                                            "firstName": "Christopher",
-                                            "lastName": "Jones",
-                                        },
-                                        "type": "ADVOCATE",
-                                    }
-                                }
-                            ]
-                        },
-                    }
-                },
-            ]
-        }
-    }
-}
-
 snapshots["test_my_profile_no_profile 1"] = {"data": {"myProfile": None}}
 
 snapshots["test_update_my_profile_mutation 1"] = {
@@ -92,6 +39,7 @@ snapshots["test_guardians_query_normal_user 1"] = {
                                             "birthdate": "2020-11-22",
                                             "firstName": "Christopher",
                                             "lastName": "Jones",
+                                            "project": {"year": 2020},
                                         },
                                         "type": "ADVOCATE",
                                     }
@@ -152,5 +100,60 @@ snapshots[
 ] = {
     "data": {
         "updateMyProfile": {"myProfile": {"email": "guardian_updated@example.com"}}
+    }
+}
+
+snapshots["test_guardians_query_project_user 1"] = {
+    "data": {
+        "guardians": {
+            "edges": [
+                {
+                    "node": {
+                        "email": "ramirezandrew@burns.com",
+                        "firstName": "Guardian having children in own and another project",
+                        "lastName": "Should be visible 1/2",
+                        "phoneNumber": "638.034.6697x2701",
+                        "relationships": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "child": {
+                                            "birthdate": "2020-09-05",
+                                            "firstName": "Craig",
+                                            "lastName": "Oneill",
+                                            "project": {"year": 2020},
+                                        },
+                                        "type": "PARENT",
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                },
+                {
+                    "node": {
+                        "email": "mperez@cox.com",
+                        "firstName": "Another project own guardian",
+                        "lastName": "Should be visible 2/2",
+                        "phoneNumber": "708-981-7101",
+                        "relationships": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "child": {
+                                            "birthdate": "2020-04-08",
+                                            "firstName": "Elizabeth",
+                                            "lastName": "Jackson",
+                                            "project": {"year": 2030},
+                                        },
+                                        "type": "ADVOCATE",
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                },
+            ]
+        }
     }
 }

--- a/users/tests/test_api.py
+++ b/users/tests/test_api.py
@@ -1,6 +1,7 @@
 import pytest
 from projects.factories import ProjectFactory
 
+from children.factories import RelationshipFactory
 from children.tests.test_api import (
     assert_guardian_matches_data,
     assert_permission_denied,
@@ -34,6 +35,9 @@ query Guardians {
                 firstName
                 lastName
                 birthdate
+                project {
+                  year
+                }
               }
             }
           }
@@ -64,15 +68,38 @@ def test_guardians_query_normal_user(snapshot, user_api_client, project):
     snapshot.assert_match(executed)
 
 
-def test_guardians_query_staff_user(snapshot, staff_api_client, project):
-    GuardianFactory(relationships__count=1, relationships__child__project=project)
-    GuardianFactory(
-        user=staff_api_client.user,
+def test_guardians_query_project_user(
+    snapshot, project_user_api_client, project, another_project
+):
+    guardian_1 = GuardianFactory(
+        first_name="Guardian having children in own and another project",
+        last_name="Should be visible 1/2",
         relationships__count=1,
         relationships__child__project=project,
     )
+    RelationshipFactory(
+        guardian=guardian_1,
+        child__first_name="Second child from another project",
+        child__last_name="Should NOT be visible",
+        child__project=another_project,
+    )
 
-    executed = staff_api_client.execute(GUARDIANS_QUERY)
+    GuardianFactory(
+        first_name="Another project own guardian",
+        last_name="Should be visible 2/2",
+        user=project_user_api_client.user,
+        relationships__count=1,
+        relationships__child__project=another_project,
+    )
+
+    GuardianFactory(
+        first_name="Another project guardian",
+        last_name="Should NOT be visible",
+        relationships__count=1,
+        relationships__child__project=another_project,
+    )
+
+    executed = project_user_api_client.execute(GUARDIANS_QUERY)
 
     snapshot.assert_match(executed)
 

--- a/users/tests/test_api.py
+++ b/users/tests/test_api.py
@@ -184,10 +184,10 @@ query MyProfile {
     snapshot.assert_match(executed)
 
 
-def test_my_profile_no_profile(snapshot, staff_api_client):
+def test_my_profile_no_profile(snapshot, user_api_client):
     GuardianFactory()
 
-    executed = staff_api_client.execute(MY_PROFILE_QUERY)
+    executed = user_api_client.execute(MY_PROFILE_QUERY)
 
     snapshot.assert_match(executed)
 

--- a/venues/models.py
+++ b/venues/models.py
@@ -37,3 +37,6 @@ class Venue(TimestampedModel, TranslatableModel):
 
     def __str__(self):
         return self.safe_translation_getter("name", super().__str__())
+
+    def can_user_administer(self, user):
+        return user.projects.filter(pk=self.project_id).exists()

--- a/venues/schema.py
+++ b/venues/schema.py
@@ -5,12 +5,14 @@ from django.db.models import Count
 from django.utils.translation import get_language
 from graphene import relay
 from graphene_django import DjangoConnectionField, DjangoObjectType
-from graphql_jwt.decorators import login_required, staff_member_required
-from graphql_relay import from_global_id
+from graphql_jwt.decorators import login_required
 from projects.models import Project
 
-from common.utils import update_object_with_translations
-from kukkuu.exceptions import ObjectDoesNotExistError
+from common.utils import (
+    get_obj_if_user_can_administer,
+    project_user_required,
+    update_object_with_translations,
+)
 from users.schema import LanguageEnum
 from venues.models import Venue
 
@@ -81,16 +83,12 @@ class AddVenueMutation(graphene.relay.ClientIDMutation):
     venue = graphene.Field(VenueNode)
 
     @classmethod
-    @staff_member_required
+    @project_user_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        # TODO: Add validation
-        project_global_id = kwargs.pop("project_id")
-        try:
-            project = Project.objects.get(pk=from_global_id(project_global_id)[1])
-            kwargs["project_id"] = project.id
-        except Project.DoesNotExist as e:
-            raise ObjectDoesNotExistError(e)
+        kwargs["project_id"] = get_obj_if_user_can_administer(
+            info, kwargs["project_id"], Project
+        ).pk
         venue = Venue.objects.create_translatable_object(**kwargs)
         return AddVenueMutation(venue=venue)
 
@@ -104,23 +102,17 @@ class UpdateVenueMutation(graphene.relay.ClientIDMutation):
     venue = graphene.Field(VenueNode)
 
     @classmethod
-    @staff_member_required
+    @project_user_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        # TODO: Add validation
-        venue_global_id = kwargs.pop("id")
         project_global_id = kwargs.pop("project_id", None)
         if project_global_id:
-            try:
-                project = Project.objects.get(pk=from_global_id(project_global_id)[1])
-                kwargs["project_id"] = project.id
-            except Project.DoesNotExist as e:
-                raise ObjectDoesNotExistError(e)
-        try:
-            venue = Venue.objects.get(pk=from_global_id(venue_global_id)[1])
-            update_object_with_translations(venue, kwargs)
-        except Venue.DoesNotExist as e:
-            raise ObjectDoesNotExistError(e)
+            kwargs["project_id"] = get_obj_if_user_can_administer(
+                info, project_global_id, Project
+            )
+        venue = get_obj_if_user_can_administer(info, kwargs.pop("id"), Venue)
+        update_object_with_translations(venue, kwargs)
+
         return UpdateVenueMutation(venue=venue)
 
 
@@ -129,16 +121,11 @@ class DeleteVenueMutation(graphene.relay.ClientIDMutation):
         id = graphene.GlobalID()
 
     @classmethod
-    @staff_member_required
+    @project_user_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        # TODO: Validate data
-        venue_id = from_global_id(kwargs["id"])[1]
-        try:
-            venue = Venue.objects.get(pk=venue_id)
-            venue.delete()
-        except Venue.DoesNotExist as e:
-            raise ObjectDoesNotExistError(e)
+        venue = get_obj_if_user_can_administer(info, kwargs["id"], Venue)
+        venue.delete()
         return DeleteVenueMutation()
 
 

--- a/venues/tests/snapshots/snap_test_api.py
+++ b/venues/tests/snapshots/snap_test_api.py
@@ -84,7 +84,7 @@ Assume training seek full several. Authority develop identify ready.""",
     }
 }
 
-snapshots["test_add_venue_staff_user 1"] = {
+snapshots["test_add_venue_project_user 1"] = {
     "data": {
         "addVenue": {
             "venue": {
@@ -107,7 +107,7 @@ snapshots["test_add_venue_staff_user 1"] = {
     }
 }
 
-snapshots["test_update_venue_staff_user 1"] = {
+snapshots["test_update_venue_project_user 1"] = {
     "data": {
         "updateVenue": {
             "venue": {

--- a/venues/tests/test_api.py
+++ b/venues/tests/test_api.py
@@ -213,7 +213,6 @@ def test_venues_query_unauthenticated(api_client):
 
 def test_venues_query_normal_user(snapshot, user_api_client, venue):
     executed = user_api_client.execute(VENUES_QUERY)
-
     snapshot.assert_match(executed)
 
 
@@ -227,24 +226,25 @@ def test_venue_query_unauthenticated(api_client, venue):
 def test_venue_query_normal_user(snapshot, user_api_client, venue):
     variables = {"id": to_global_id("VenueNode", venue.id)}
     executed = user_api_client.execute(VENUE_QUERY, variables=variables)
-
     snapshot.assert_match(executed)
 
 
-def test_add_venue_permission_denied(api_client, user_api_client):
-    executed = api_client.execute(ADD_VENUE_MUTATION, variables=ADD_VENUE_VARIABLES)
-    assert_permission_denied(executed)
+def test_add_venue_permission_denied(unauthorized_user_api_client, project):
+    venue_variables = deepcopy(ADD_VENUE_VARIABLES)
+    venue_variables["input"]["projectId"] = to_global_id("ProjectNode", project.id)
 
-    executed = user_api_client.execute(
-        ADD_VENUE_MUTATION, variables=ADD_VENUE_VARIABLES
+    executed = unauthorized_user_api_client.execute(
+        ADD_VENUE_MUTATION, variables=venue_variables
     )
     assert_permission_denied(executed)
 
 
-def test_add_venue_staff_user(snapshot, staff_api_client, project):
+def test_add_venue_project_user(snapshot, project_user_api_client, project):
     venue_variables = deepcopy(ADD_VENUE_VARIABLES)
     venue_variables["input"]["projectId"] = to_global_id("ProjectNode", project.id)
-    executed = staff_api_client.execute(ADD_VENUE_MUTATION, variables=venue_variables)
+    executed = project_user_api_client.execute(
+        ADD_VENUE_MUTATION, variables=venue_variables
+    )
     snapshot.assert_match(executed)
 
 
@@ -260,10 +260,10 @@ def test_update_venue_permission_denied(api_client, user_api_client):
     assert_permission_denied(executed)
 
 
-def test_update_venue_staff_user(snapshot, staff_api_client, venue):
+def test_update_venue_project_user(snapshot, project_user_api_client, venue):
     venue_variables = deepcopy(UPDATE_VENUE_VARIABLES)
     venue_variables["input"]["id"] = to_global_id("VenueNode", venue.id)
-    executed = staff_api_client.execute(
+    executed = project_user_api_client.execute(
         UPDATE_VENUE_MUTATION, variables=venue_variables
     )
     snapshot.assert_match(executed)
@@ -281,8 +281,8 @@ def test_delete_venue_permission_denied(api_client, user_api_client):
     assert_permission_denied(executed)
 
 
-def test_delete_venue_staff_user(staff_api_client, venue):
-    staff_api_client.execute(
+def test_delete_venue_project_user(project_user_api_client, venue):
+    project_user_api_client.execute(
         DELETE_VENUE_MUTATION,
         variables={"input": {"id": to_global_id("VenueNode", venue.id)}},
     )


### PR DESCRIPTION
Changed viewing and admin CRUD mutations of Guardians (view only) Children (view only), Venues, Events and Occurrences to be allowed only for the corresponding project admins instead of all staff members like before.

Still to do later: Could use some new tests that check that a project admin of a different project cannot use the mutations. This is however not critical, because exploiting a possible hole would require a wrongdoer in the project admin group.

