### PR TITLE
KK-425 & KK-488 | Fix bug in OccurrenceNode remainingCapacity and enrolmentCount fields

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -127,6 +127,13 @@ class Occurrence(TimestampedModel):
     def __str__(self):
         return f"{self.pk} {self.time}"
 
+    def get_enrolment_count(self):
+        try:
+            # try to use an annotated value
+            return self.enrolment_count
+        except AttributeError:
+            return self.enrolments.count()
+
 
 class Enrolment(models.Model):
     child = models.ForeignKey(

--- a/events/schema.py
+++ b/events/schema.py
@@ -120,7 +120,10 @@ class OccurrenceNode(DjangoObjectType):
         return super().get_node(info, id)
 
     def resolve_remaining_capacity(self, info, **kwargs):
-        return self.event.capacity_per_occurrence - self.enrolment_count
+        return self.event.capacity_per_occurrence - self.get_enrolment_count()
+
+    def resolve_enrolment_count(self, info, **kwargs):
+        return self.get_enrolment_count()
 
     class Meta:
         model = Occurrence

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -126,8 +126,10 @@ snapshots["test_update_occurrence_staff_user 1"] = {
     "data": {
         "updateOccurrence": {
             "occurrence": {
+                "enrolmentCount": 0,
                 "event": {"createdAt": "2020-12-12T00:00:00+00:00"},
                 "occurrenceLanguage": "SV",
+                "remainingCapacity": 43,
                 "time": "1986-12-12T16:40:48+00:00",
                 "venue": {"createdAt": "2020-12-12T00:00:00+00:00"},
             }

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -378,6 +378,8 @@ mutation UpdateOccurrence($input: UpdateOccurrenceMutationInput!) {
       }
       time
       occurrenceLanguage
+      enrolmentCount
+      remainingCapacity
     }
   }
 }


### PR DESCRIPTION
Because OccurrenceNode remainingCapacity and enrolmentCount fields
relied on annotated enrolmentCount to be available, they failed when
it wasn't available, like when doing UpdateOccurrenceMutation. Now
those fields will fallback to calculating the value for enrolmentCount
when it is not annotated.