### PR TITLE
KK-473 | Children limit / offset pagination

### DIFF
--- a/children/schema.py
+++ b/children/schema.py
@@ -34,6 +34,16 @@ User = get_user_model()
 logger = logging.getLogger(__name__)
 
 
+class ChildrenConnection(graphene.Connection):
+    class Meta:
+        abstract = True
+
+    count = graphene.Int(required=True)
+
+    def resolve_count(self, info, **kwargs):
+        return self.length
+
+
 class ChildNode(DjangoObjectType):
     available_events = relay.ConnectionField("events.schema.EventConnection")
     past_events = relay.ConnectionField("events.schema.EventConnection")
@@ -41,6 +51,7 @@ class ChildNode(DjangoObjectType):
     class Meta:
         model = Child
         interfaces = (relay.Node,)
+        connection_class = ChildrenConnection
         filter_fields = ("project_id",)
 
     @classmethod

--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -454,3 +454,9 @@ snapshots["test_children_offset_pagination[10-None] 1"] = {
 snapshots["test_children_offset_pagination[None-5] 1"] = {
     "data": {"children": {"edges": []}}
 }
+
+snapshots["test_children_total_count[None] 1"] = {"data": {"children": {"count": 5}}}
+
+snapshots["test_children_total_count[limit] 1"] = {"data": {"children": {"count": 5}}}
+
+snapshots["test_children_total_count[first] 1"] = {"data": {"children": {"count": 5}}}

--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -408,3 +408,49 @@ snapshots["test_children_project_filter 1"] = {
         }
     }
 }
+
+snapshots["test_children_offset_pagination[None-2] 1"] = {
+    "data": {
+        "children": {
+            "edges": [
+                {"node": {"lastName": "2"}},
+                {"node": {"lastName": "3"}},
+                {"node": {"lastName": "4"}},
+            ]
+        }
+    }
+}
+
+snapshots["test_children_offset_pagination[2-None] 1"] = {
+    "data": {
+        "children": {
+            "edges": [{"node": {"lastName": "0"}}, {"node": {"lastName": "1"}}]
+        }
+    }
+}
+
+snapshots["test_children_offset_pagination[2-2] 1"] = {
+    "data": {
+        "children": {
+            "edges": [{"node": {"lastName": "2"}}, {"node": {"lastName": "3"}}]
+        }
+    }
+}
+
+snapshots["test_children_offset_pagination[10-None] 1"] = {
+    "data": {
+        "children": {
+            "edges": [
+                {"node": {"lastName": "0"}},
+                {"node": {"lastName": "1"}},
+                {"node": {"lastName": "2"}},
+                {"node": {"lastName": "3"}},
+                {"node": {"lastName": "4"}},
+            ]
+        }
+    }
+}
+
+snapshots["test_children_offset_pagination[None-5] 1"] = {
+    "data": {"children": {"edges": []}}
+}

--- a/children/tests/test_api.py
+++ b/children/tests/test_api.py
@@ -859,3 +859,26 @@ def test_children_offset_pagination(
     )
 
     snapshot.assert_match(executed)
+
+
+@pytest.mark.parametrize("pagination", (None, "limit", "first"))
+def test_children_total_count(
+    snapshot, project_user_api_client, project, another_project, pagination
+):
+    ChildWithGuardianFactory.create_batch(5, project=project)
+    ChildWithGuardianFactory.create_batch(5, project=another_project)
+    variables = {"projectId": get_global_id(project)}
+    if pagination:
+        variables.update({pagination: 2})
+
+    executed = project_user_api_client.execute(
+        """
+query Children($projectId: ID!, $limit: Int, $first: Int) {
+  children(projectId: $projectId, limit: $limit, first: $first) {
+    count
+  }
+}""",
+        variables=variables,
+    )
+
+    snapshot.assert_match(executed)


### PR DESCRIPTION
To support jumping straight into a specific page of results in children query, added limit and offset based pagination alongside the existing cursor based pagination.