### PR TITLE
KK-465 | Always hide unpublished events in child node event fields

### DIFF
--- a/children/schema.py
+++ b/children/schema.py
@@ -72,6 +72,7 @@ class ChildNode(DjangoObjectType):
     def resolve_past_events(self, info, **kwargs):
         return (
             self.project.events.user_can_view(info.context.user)
+            .published()
             .exclude(occurrences__time__gte=timezone.now())
             .distinct()
         )
@@ -79,6 +80,7 @@ class ChildNode(DjangoObjectType):
     def resolve_available_events(self, info, **kwargs):
         return (
             self.project.events.user_can_view(info.context.user)
+            .published()
             .filter(occurrences__time__gte=timezone.now())
             .distinct()
             .exclude(occurrences__in=self.occurrences.all())

--- a/children/tests/test_api.py
+++ b/children/tests/test_api.py
@@ -759,6 +759,15 @@ def test_get_available_events(
     assert len(executed["data"]["child"]["availableEvents"]["edges"]) == 1
     snapshot.assert_match(executed)
 
+    guardian_api_client.user.projects.add(project)
+    executed2 = guardian_api_client.execute(CHILD_EVENTS_QUERY, variables=variables)
+
+    # having admin rights on the project should not affect available events
+    assert (
+        executed2["data"]["child"]["availableEvents"]
+        == executed["data"]["child"]["availableEvents"]
+    )
+
 
 def test_get_past_events(
     snapshot, guardian_api_client, child_with_user_guardian, project, venue
@@ -812,6 +821,15 @@ def test_get_past_events(
     # Should only return past events from current project
     assert len(executed["data"]["child"]["pastEvents"]["edges"]) == 1
     snapshot.assert_match(executed)
+
+    guardian_api_client.user.projects.add(project)
+    executed2 = guardian_api_client.execute(CHILD_EVENTS_QUERY, variables=variables)
+
+    # having admin rights on the project should not affect past events
+    assert (
+        executed2["data"]["child"]["pastEvents"]
+        == executed["data"]["child"]["pastEvents"]
+    )
 
 
 CHILDREN_PAGINATION_QUERY = """

--- a/events/models.py
+++ b/events/models.py
@@ -20,6 +20,9 @@ class EventQueryset(TranslatableQuerySet):
             Q(project__users=user) | Q(published_at__isnull=False)
         ).distinct()
 
+    def published(self):
+        return self.filter(published_at__isnull=False)
+
 
 class Event(TimestampedModel, TranslatableModel):
     CHILD_AND_GUARDIAN = "child_and_guardian"


### PR DESCRIPTION
Previously unpublished events were returned in child queries'
past_events and available_events fields if the current user was a
project admin.