### PR TITLE
KK-566 | Changes to event showing logic

### DIFF
--- a/children/schema.py
+++ b/children/schema.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 
 import graphene
 from django.conf import settings
@@ -92,12 +93,29 @@ class ChildNode(DjangoObjectType):
             return None
 
     def resolve_past_events(self, info, **kwargs):
-        return (
-            self.project.events.user_can_view(info.context.user)
-            .published()
-            .exclude(occurrences__time__gte=timezone.now())
-            .distinct()
+        """
+        Past events include:
+
+        1) Events the user has not enrolled AND are completely (all occurrences) in the
+           past
+        2) Events the user has enrolled AND the occurrence of the enrolment is more than
+           KUKKUU_ENROLLED_OCCURRENCE_IN_PAST_LEEWAY mins in the past.
+        """
+        events = self.project.events.user_can_view(info.context.user).published()
+
+        past_unparticipated_events = events.exclude(
+            occurrences__in=self.occurrences.all()
+        ).exclude(occurrences__time__gte=timezone.now())
+
+        past_enough_enrolled_occurrences = self.occurrences.filter(
+            time__lt=timezone.now()
+            - timedelta(minutes=settings.KUKKUU_ENROLLED_OCCURRENCE_IN_PAST_LEEWAY)
         )
+        past_enough_participated_events = events.filter(
+            occurrences__in=past_enough_enrolled_occurrences
+        )
+
+        return past_unparticipated_events | past_enough_participated_events
 
     def resolve_available_events(self, info, **kwargs):
         return (

--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -378,27 +378,6 @@ snapshots["test_get_available_events 1"] = {
     }
 }
 
-snapshots["test_get_past_events 1"] = {
-    "data": {
-        "child": {
-            "availableEvents": {"edges": []},
-            "occurrences": {"edges": [{"node": {"time": "1969-12-31T22:20:00+00:00"}}]},
-            "pastEvents": {
-                "edges": [
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 0}}]
-                            },
-                        }
-                    }
-                ]
-            },
-        }
-    }
-}
-
 snapshots["test_children_project_filter 1"] = {
     "data": {
         "children": {
@@ -536,6 +515,62 @@ snapshots["test_children_query_ordering 1"] = {
                     }
                 },
             ]
+        }
+    }
+}
+
+snapshots["test_get_past_events 1"] = {
+    "data": {
+        "child": {
+            "availableEvents": {
+                "edges": [
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "occurrences": {
+                                "edges": [
+                                    {"node": {"remainingCapacity": 0}},
+                                    {"node": {"remainingCapacity": 0}},
+                                ]
+                            },
+                        }
+                    }
+                ]
+            },
+            "occurrences": {
+                "edges": [
+                    {"node": {"time": "2020-12-11T23:29:00+00:00"}},
+                    {"node": {"time": "2020-12-11T23:31:00+00:00"}},
+                ]
+            },
+            "pastEvents": {
+                "edges": [
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "name": "enrolled occurrence in the past",
+                            "occurrences": {
+                                "edges": [
+                                    {"node": {"remainingCapacity": 23}},
+                                    {"node": {"remainingCapacity": 24}},
+                                ]
+                            },
+                        }
+                    },
+                    {
+                        "node": {
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "name": "event in the past",
+                            "occurrences": {
+                                "edges": [
+                                    {"node": {"remainingCapacity": 32}},
+                                    {"node": {"remainingCapacity": 32}},
+                                ]
+                            },
+                        }
+                    },
+                ]
+            },
         }
     }
 }

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -811,3 +811,20 @@ snapshots["test_occurrence_capacity[None-11] 1"] = {
         }
     }
 }
+
+snapshots["test_occurrences_filter_by_upcoming_with_leeway[True] 1"] = {
+    "data": {
+        "occurrences": {"edges": [{"node": {"time": "2020-12-11T23:31:00+00:00"}}]}
+    }
+}
+
+snapshots["test_occurrences_filter_by_upcoming_with_leeway[False] 1"] = {
+    "data": {
+        "occurrences": {
+            "edges": [
+                {"node": {"time": "2020-12-11T23:29:00+00:00"}},
+                {"node": {"time": "2020-12-11T23:31:00+00:00"}},
+            ]
+        }
+    }
+}

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -53,6 +53,7 @@ env = environ.Env(
     AZURE_CONTAINER=(str, ""),
     ENABLE_GRAPHIQL=(bool, False),
     KUKKUU_UI_BASE_URL=(str, "http://localhost:3000"),
+    KUKKUU_ENROLLED_OCCURRENCE_IN_PAST_LEEWAY=(int, 30),
 )
 
 if os.path.exists(env_file):
@@ -217,6 +218,11 @@ GRAPHQL_JWT = {"JWT_AUTH_HEADER_PREFIX": "Bearer"}
 KUKKUU_MAX_NUM_OF_CHILDREN_PER_GUARDIAN = 100
 KUKKUU_QUERY_MAX_DEPTH = 12
 KUKKUU_UI_BASE_URL = env("KUKKUU_UI_BASE_URL")
+# How much an enrolled occurrence can be in the past and still be considered as
+# not being in the past. In minutes.
+KUKKUU_ENROLLED_OCCURRENCE_IN_PAST_LEEWAY = env(
+    "KUKKUU_ENROLLED_OCCURRENCE_IN_PAST_LEEWAY"
+)
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
Implemented needed changes so that the UI can

* show enrolled events until half an hour after the occurrence has started
* show participated events as past events when the participated occurrence has passed

Implementation details in the commit messages.