### PR TITLE
Fix API version string

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -32,7 +32,7 @@ def update_object_with_translations(model, model_data):
 
 
 def get_api_version():
-    return " | ".join((__version__, REVISION.decode("utf-8")))
+    return " | ".join((__version__, REVISION))
 
 
 def get_global_id(obj):

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -88,7 +88,11 @@ ILMOITIN_TRANSLATED_FROM_EMAIL = env("ILMOITIN_TRANSLATED_FROM_EMAIL")
 ILMOITIN_QUEUE_NOTIFICATIONS = env("ILMOITIN_QUEUE_NOTIFICATIONS")
 
 try:
-    REVISION = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).strip()
+    REVISION = (
+        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+        .strip()
+        .decode("utf-8")
+    )
 except Exception:
     REVISION = "n/a"
 


### PR DESCRIPTION
Previously trying to get the API version was throwing an exception
when the revision could not be figured out, for example when running a
management script from outside the app's directory.