### PR TITLE
KK-637 | Add recipient count to unsent messages

### DIFF
--- a/messaging/admin.py
+++ b/messaging/admin.py
@@ -11,7 +11,7 @@ class MessageAdmin(TranslatableAdmin):
         "subject",
         "project",
         "sent_at",
-        "recipient_count",
+        "get_recipient_count",
         "created_at",
         "updated_at",
     )
@@ -24,10 +24,17 @@ class MessageAdmin(TranslatableAdmin):
         "occurrences",
         "created_at",
         "updated_at",
-        "recipient_count",
+        "get_recipient_count",
     )
-    readonly_fields = ("recipient_count", "created_at", "updated_at")
+    readonly_fields = ("get_recipient_count", "created_at", "updated_at")
     actions = ("send",)
+
+    def get_recipient_count(self, obj):
+        return str(obj.get_recipient_count()) + (
+            str(_(" (if sent now)")) if not obj.sent_at else ""
+        )
+
+    get_recipient_count.short_description = _("recipient count")
 
     def send(self, request, queryset):
         sent_count = 0

--- a/messaging/models.py
+++ b/messaging/models.py
@@ -84,6 +84,13 @@ class Message(TimestampedModel, TranslatableModel):
     def __str__(self):
         return f"({self.pk}) {self.subject} ({self.sent_at or 'not sent'})"
 
+    def get_recipient_count(self):
+        return (
+            self.recipient_count
+            if self.sent_at
+            else self.get_recipient_guardians().count()
+        )
+
     def send(self, *, force=False):
         if self.sent_at and not force:
             raise AlreadySentError()

--- a/messaging/schema.py
+++ b/messaging/schema.py
@@ -82,6 +82,9 @@ class MessageNode(DjangoObjectType):
         except cls._meta.model.DoesNotExist:
             return None
 
+    def resolve_recipient_count(self, info, **kwargs):
+        return self.get_recipient_count()
+
 
 class MessageTranslationsInput(graphene.InputObjectType):
     language_code = LanguageEnum(required=True)

--- a/messaging/tests/snapshots/snap_test_api.py
+++ b/messaging/tests/snapshots/snap_test_api.py
@@ -13,7 +13,7 @@ snapshots["test_add_message[None] 1"] = {
                 "event": None,
                 "occurrences": {"edges": []},
                 "project": {"year": 2020},
-                "recipientCount": None,
+                "recipientCount": 0,
                 "recipientSelection": "ALL",
                 "sentAt": None,
                 "translations": [
@@ -35,7 +35,7 @@ snapshots["test_add_message[event] 1"] = {
                 "event": {"name": "Free heart significant machine try."},
                 "occurrences": {"edges": []},
                 "project": {"year": 2020},
-                "recipientCount": None,
+                "recipientCount": 0,
                 "recipientSelection": "ALL",
                 "sentAt": None,
                 "translations": [
@@ -63,7 +63,7 @@ snapshots["test_add_message[occurrences] 1"] = {
                     ]
                 },
                 "project": {"year": 2020},
-                "recipientCount": None,
+                "recipientCount": 0,
                 "recipientSelection": "ALL",
                 "sentAt": None,
                 "translations": [
@@ -93,7 +93,7 @@ snapshots["test_message_query 1"] = {
             "event": None,
             "occurrences": {"edges": []},
             "project": {"year": 2020},
-            "recipientCount": None,
+            "recipientCount": 0,
             "recipientSelection": "ALL",
             "sentAt": None,
             "subject": "Otsikko",
@@ -111,7 +111,7 @@ snapshots["test_messages_query 1"] = {
                         "event": None,
                         "occurrences": {"edges": []},
                         "project": {"year": 2020},
-                        "recipientCount": None,
+                        "recipientCount": 0,
                         "recipientSelection": "ALL",
                         "sentAt": None,
                         "subject": "Otsikko",
@@ -132,7 +132,7 @@ snapshots["test_messages_query_project_filter 1"] = {
                         "event": None,
                         "occurrences": {"edges": []},
                         "project": {"year": 2020},
-                        "recipientCount": None,
+                        "recipientCount": 0,
                         "recipientSelection": "ALL",
                         "sentAt": None,
                         "subject": "Otsikko",
@@ -162,7 +162,7 @@ snapshots["test_update_message[None] 1"] = {
                 "event": {"name": "Free heart significant machine try."},
                 "occurrences": {"edges": []},
                 "project": {"year": 2020},
-                "recipientCount": None,
+                "recipientCount": 0,
                 "recipientSelection": "ATTENDED",
                 "sentAt": None,
                 "translations": [
@@ -186,7 +186,7 @@ snapshots["test_update_message[event] 1"] = {
                 },
                 "occurrences": {"edges": []},
                 "project": {"year": 2020},
-                "recipientCount": None,
+                "recipientCount": 0,
                 "recipientSelection": "ATTENDED",
                 "sentAt": None,
                 "translations": [
@@ -212,7 +212,7 @@ snapshots["test_update_message[event_and_occurrences] 1"] = {
                     "edges": [{"node": {"time": "2016-08-16T07:10:00+00:00"}}]
                 },
                 "project": {"year": 2020},
-                "recipientCount": None,
+                "recipientCount": 0,
                 "recipientSelection": "ATTENDED",
                 "sentAt": None,
                 "translations": [


### PR DESCRIPTION
Recipient count for an unsent message will be populated with the amount
of recipients there would be if the message was sent at that current
time.