### PR TITLE
Disable django-parler caching

### DIFF
--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -697,7 +697,7 @@ def test_update_event_translations(project_user_api_client, event):
         "name": "Event name",
         "description": "Event description",
         "shortDescription": "Event short description",
-        "languageCode": "SV",
+        "languageCode": "EN",
     }
     event_variables["input"]["translations"].append(new_translation)
     project_user_api_client.execute(UPDATE_EVENT_MUTATION, variables=event_variables)

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -214,6 +214,8 @@ PARLER_LANGUAGES = {SITE_ID: ({"code": "fi"}, {"code": "sv"}, {"code": "en"})}
 
 PARLER_SUPPORTED_LANGUAGE_CODES = [x["code"] for x in PARLER_LANGUAGES[SITE_ID]]
 
+PARLER_ENABLE_CACHING = False
+
 GRAPHENE = {
     "SCHEMA": "kukkuu.schema.schema",
     "MIDDLEWARE": ["graphql_jwt.middleware.JSONWebTokenMiddleware"],


### PR DESCRIPTION
django-parler uses caching by default. That causes problems when there
are multiple Django processes and no proper cache backend in use
(which is exactly the situation in our QA and production envs ATM).