### PR TITLE
Compile requirements using pip-tools 5.5

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,59 +4,144 @@
 #
 #    pip-compile requirements-dev.in
 #
-appdirs==1.4.3            # via black
-appnope==0.1.0            # via ipython
-atomicwrites==1.3.0       # via pytest
-attrs==19.2.0             # via black, pytest
-backcall==0.1.0           # via ipython
-black==19.10b0            # via -r requirements-dev.in
-certifi==2019.9.11        # via -c requirements.txt, requests
-chardet==3.0.4            # via -c requirements.txt, requests
-click==7.0                # via black
-coverage==4.5.4           # via pytest-cov
-decorator==4.4.0          # via ipython, traitlets
-entrypoints==0.3          # via flake8
-fastdiff==0.2.0           # via snapshottest
-flake8==3.7.8             # via -r requirements-dev.in
-freezegun==0.3.12         # via -r requirements-dev.in
-idna==2.8                 # via -c requirements.txt, requests
-importlib-metadata==0.23  # via pluggy, pytest
-ipython-genutils==0.2.0   # via traitlets
-ipython==7.8.0            # via -r requirements-dev.in
-isort==4.3.21             # via -r requirements-dev.in
-jedi==0.15.1              # via ipython
-mccabe==0.6.1             # via flake8
-more-itertools==7.2.0     # via pytest
-packaging==19.2           # via pytest
-parso==0.5.1              # via jedi
-pathspec==0.6.0           # via black
-pexpect==4.7.0            # via ipython
-pickleshare==0.7.5        # via ipython
-pluggy==0.13.0            # via pytest
-prompt-toolkit==2.0.10    # via ipython
-ptyprocess==0.6.0         # via pexpect
-py==1.8.0                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8
-pygments==2.4.2           # via ipython
-pyparsing==2.4.2          # via packaging
-pytest-cov==2.8.1         # via -r requirements-dev.in
-pytest-django==3.5.1      # via -r requirements-dev.in
-pytest==5.2.1             # via -r requirements-dev.in, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -c requirements.txt, freezegun
-regex==2019.11.1          # via black
-requests==2.22.0          # via -c requirements.txt, responses
-responses==0.12.1         # via -r requirements-dev.in
-six==1.12.0               # via -c requirements.txt, freezegun, packaging, prompt-toolkit, python-dateutil, responses, snapshottest, traitlets
-snapshottest==0.6.0       # via -r requirements-dev.in
-termcolor==1.1.0          # via snapshottest
-toml==0.10.0              # via black
-traitlets==4.3.3          # via ipython
-typed-ast==1.4.0          # via black
-urllib3==1.25.11          # via -c requirements.txt, requests, responses
-wasmer==0.3.0             # via fastdiff
-wcwidth==0.1.7            # via prompt-toolkit, pytest
-zipp==0.6.0               # via importlib-metadata
+appdirs==1.4.3
+    # via black
+appnope==0.1.0
+    # via ipython
+atomicwrites==1.3.0
+    # via pytest
+attrs==19.2.0
+    # via
+    #   black
+    #   pytest
+backcall==0.1.0
+    # via ipython
+black==19.10b0
+    # via -r requirements-dev.in
+certifi==2019.9.11
+    # via
+    #   -c requirements.txt
+    #   requests
+chardet==3.0.4
+    # via
+    #   -c requirements.txt
+    #   requests
+click==7.0
+    # via black
+coverage==4.5.4
+    # via pytest-cov
+decorator==4.4.0
+    # via
+    #   ipython
+    #   traitlets
+entrypoints==0.3
+    # via flake8
+fastdiff==0.2.0
+    # via snapshottest
+flake8==3.7.8
+    # via -r requirements-dev.in
+freezegun==0.3.12
+    # via -r requirements-dev.in
+idna==2.8
+    # via
+    #   -c requirements.txt
+    #   requests
+importlib-metadata==0.23
+    # via
+    #   pluggy
+    #   pytest
+ipython-genutils==0.2.0
+    # via traitlets
+ipython==7.8.0
+    # via -r requirements-dev.in
+isort==4.3.21
+    # via -r requirements-dev.in
+jedi==0.15.1
+    # via ipython
+mccabe==0.6.1
+    # via flake8
+more-itertools==7.2.0
+    # via pytest
+packaging==19.2
+    # via pytest
+parso==0.5.1
+    # via jedi
+pathspec==0.6.0
+    # via black
+pexpect==4.7.0
+    # via ipython
+pickleshare==0.7.5
+    # via ipython
+pluggy==0.13.0
+    # via pytest
+prompt-toolkit==2.0.10
+    # via ipython
+ptyprocess==0.6.0
+    # via pexpect
+py==1.8.0
+    # via pytest
+pycodestyle==2.5.0
+    # via flake8
+pyflakes==2.1.1
+    # via flake8
+pygments==2.4.2
+    # via ipython
+pyparsing==2.4.2
+    # via packaging
+pytest-cov==2.8.1
+    # via -r requirements-dev.in
+pytest-django==3.5.1
+    # via -r requirements-dev.in
+pytest==5.2.1
+    # via
+    #   -r requirements-dev.in
+    #   pytest-cov
+    #   pytest-django
+python-dateutil==2.8.1
+    # via
+    #   -c requirements.txt
+    #   freezegun
+regex==2019.11.1
+    # via black
+requests==2.22.0
+    # via
+    #   -c requirements.txt
+    #   responses
+responses==0.12.1
+    # via -r requirements-dev.in
+six==1.12.0
+    # via
+    #   -c requirements.txt
+    #   freezegun
+    #   packaging
+    #   prompt-toolkit
+    #   python-dateutil
+    #   responses
+    #   snapshottest
+    #   traitlets
+snapshottest==0.6.0
+    # via -r requirements-dev.in
+termcolor==1.1.0
+    # via snapshottest
+toml==0.10.0
+    # via black
+traitlets==4.3.3
+    # via ipython
+typed-ast==1.4.0
+    # via black
+urllib3==1.25.11
+    # via
+    #   -c requirements.txt
+    #   requests
+    #   responses
+wasmer==0.3.0
+    # via fastdiff
+wcwidth==0.1.7
+    # via
+    #   prompt-toolkit
+    #   pytest
+zipp==0.6.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -5,3 +5,4 @@
 #    pip-compile requirements-prod.in
 #
 uwsgi==2.0.18
+    # via -r requirements-prod.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,73 +4,208 @@
 #
 #    pip-compile requirements.in
 #
-aniso8601==7.0.0          # via graphene
-azure-common==1.1.25      # via azure-storage-blob, azure-storage-common
-azure-storage-blob==2.1.0  # via django-storages
-azure-storage-common==2.1.0  # via azure-storage-blob
-cachetools==4.0.0         # via google-auth
-certifi==2019.9.11        # via requests, sentry-sdk
-cffi==1.14.0              # via cryptography
-chardet==3.0.4            # via requests
-cryptography==3.2         # via azure-storage-common
-django-anymail==7.0.0     # via django-ilmoitin
-django-cleanup==4.0.0     # via -r requirements.in
-django-cors-headers==3.1.1  # via -r requirements.in
-django-environ==0.4.5     # via -r requirements.in
-django-filter==2.2.0      # via -r requirements.in
-django-graphql-jwt==0.2.2  # via -r requirements.in
-django-guardian==2.3.0    # via -r requirements.in
-django-helusers==0.5.6    # via -r requirements.in
-django-ilmoitin==0.6.0    # via -r requirements.in
-django-mailer==2.0        # via django-ilmoitin
-django-parler==2.1        # via -r requirements.in, django-ilmoitin
-django-storages[azure,google]==1.9.1  # via -r requirements.in
-django==2.2.13            # via -r requirements.in, django-anymail, django-cors-headers, django-filter, django-graphql-jwt, django-guardian, django-helusers, django-ilmoitin, django-mailer, django-storages, drf-oidc-auth, graphene-django
-djangorestframework==3.10.3  # via drf-oidc-auth
-drf-oidc-auth==0.9        # via django-helusers
-ecdsa==0.13.3             # via python-jose
-factory-boy==2.12.0       # via -r requirements.in
-faker==2.0.4              # via factory-boy
-future==0.17.1            # via pyjwkest, python-jose
-google-api-core==1.16.0   # via google-cloud-core
-google-auth==1.11.2       # via google-api-core, google-cloud-storage
-google-cloud-core==1.3.0  # via google-cloud-storage
-google-cloud-storage==1.26.0  # via django-storages
-google-resumable-media==0.5.0  # via google-cloud-storage
-googleapis-common-protos==1.51.0  # via google-api-core
-graphene-django==2.13.0   # via -r requirements.in, django-graphql-jwt
-graphene-file-upload==1.2.2  # via -r requirements.in
-graphene==2.1.8           # via graphene-django
-graphql-core==2.2.1       # via django-graphql-jwt, graphene, graphene-django, graphql-relay
-graphql-relay==2.0.0      # via graphene
-idna==2.8                 # via requests
-jinja2==2.10.3            # via django-ilmoitin
-lockfile==0.12.2          # via django-mailer
-markupsafe==1.1.1         # via jinja2
-pillow==7.1.0             # via -r requirements.in
-promise==2.2.1            # via graphene-django, graphql-core, graphql-relay
-protobuf==3.11.3          # via google-api-core, googleapis-common-protos
-psycopg2==2.8.4           # via -r requirements.in
-pyasn1-modules==0.2.8     # via google-auth
-pyasn1==0.4.7             # via pyasn1-modules, rsa
-pycountry==20.7.3         # via -r requirements.in
-pycparser==2.20           # via cffi
-pycryptodomex==3.9.0      # via pyjwkest
-pyjwkest==1.4.2           # via drf-oidc-auth
-pyjwt==1.7.1              # via django-graphql-jwt
-python-dateutil==2.8.1    # via azure-storage-common, faker
-python-jose==3.0.1        # via django-helusers
-pytz==2019.3              # via django, google-api-core
-requests==2.22.0          # via -r requirements.in, azure-storage-common, django-anymail, django-helusers, google-api-core, pyjwkest
-rsa==4.0                  # via google-auth, python-jose
-rx==1.6.1                 # via graphql-core
-sentry-sdk==0.12.3        # via -r requirements.in
-singledispatch==3.4.0.3   # via graphene-django
-six==1.12.0               # via cryptography, django-anymail, django-mailer, django-parler, faker, google-api-core, google-auth, google-resumable-media, graphene, graphene-django, graphene-file-upload, graphql-core, graphql-relay, promise, protobuf, pyjwkest, python-dateutil, python-jose, singledispatch
-sqlparse==0.3.0           # via django
-text-unidecode==1.3       # via faker
-unidecode==1.1.1          # via graphene-django
-urllib3==1.25.11          # via requests, sentry-sdk
+aniso8601==7.0.0
+    # via graphene
+azure-common==1.1.25
+    # via
+    #   azure-storage-blob
+    #   azure-storage-common
+azure-storage-blob==2.1.0
+    # via django-storages
+azure-storage-common==2.1.0
+    # via azure-storage-blob
+cachetools==4.0.0
+    # via google-auth
+certifi==2019.9.11
+    # via
+    #   requests
+    #   sentry-sdk
+cffi==1.14.0
+    # via cryptography
+chardet==3.0.4
+    # via requests
+cryptography==3.2
+    # via azure-storage-common
+django-anymail==7.0.0
+    # via django-ilmoitin
+django-cleanup==4.0.0
+    # via -r requirements.in
+django-cors-headers==3.1.1
+    # via -r requirements.in
+django-environ==0.4.5
+    # via -r requirements.in
+django-filter==2.2.0
+    # via -r requirements.in
+django-graphql-jwt==0.2.2
+    # via -r requirements.in
+django-guardian==2.3.0
+    # via -r requirements.in
+django-helusers==0.5.6
+    # via -r requirements.in
+django-ilmoitin==0.6.0
+    # via -r requirements.in
+django-mailer==2.0
+    # via django-ilmoitin
+django-parler==2.1
+    # via
+    #   -r requirements.in
+    #   django-ilmoitin
+django-storages[azure,google]==1.9.1
+    # via -r requirements.in
+django==2.2.13
+    # via
+    #   -r requirements.in
+    #   django-anymail
+    #   django-cors-headers
+    #   django-filter
+    #   django-graphql-jwt
+    #   django-guardian
+    #   django-helusers
+    #   django-ilmoitin
+    #   django-mailer
+    #   django-storages
+    #   drf-oidc-auth
+    #   graphene-django
+djangorestframework==3.10.3
+    # via drf-oidc-auth
+drf-oidc-auth==0.9
+    # via django-helusers
+ecdsa==0.13.3
+    # via python-jose
+factory-boy==2.12.0
+    # via -r requirements.in
+faker==2.0.4
+    # via factory-boy
+future==0.17.1
+    # via
+    #   pyjwkest
+    #   python-jose
+google-api-core==1.16.0
+    # via google-cloud-core
+google-auth==1.11.2
+    # via
+    #   google-api-core
+    #   google-cloud-storage
+google-cloud-core==1.3.0
+    # via google-cloud-storage
+google-cloud-storage==1.26.0
+    # via django-storages
+google-resumable-media==0.5.0
+    # via google-cloud-storage
+googleapis-common-protos==1.51.0
+    # via google-api-core
+graphene-django==2.13.0
+    # via
+    #   -r requirements.in
+    #   django-graphql-jwt
+graphene-file-upload==1.2.2
+    # via -r requirements.in
+graphene==2.1.8
+    # via graphene-django
+graphql-core==2.2.1
+    # via
+    #   django-graphql-jwt
+    #   graphene
+    #   graphene-django
+    #   graphql-relay
+graphql-relay==2.0.0
+    # via graphene
+idna==2.8
+    # via requests
+jinja2==2.10.3
+    # via django-ilmoitin
+lockfile==0.12.2
+    # via django-mailer
+markupsafe==1.1.1
+    # via jinja2
+pillow==7.1.0
+    # via -r requirements.in
+promise==2.2.1
+    # via
+    #   graphene-django
+    #   graphql-core
+    #   graphql-relay
+protobuf==3.11.3
+    # via
+    #   google-api-core
+    #   googleapis-common-protos
+psycopg2==2.8.4
+    # via -r requirements.in
+pyasn1-modules==0.2.8
+    # via google-auth
+pyasn1==0.4.7
+    # via
+    #   pyasn1-modules
+    #   rsa
+pycountry==20.7.3
+    # via -r requirements.in
+pycparser==2.20
+    # via cffi
+pycryptodomex==3.9.0
+    # via pyjwkest
+pyjwkest==1.4.2
+    # via drf-oidc-auth
+pyjwt==1.7.1
+    # via django-graphql-jwt
+python-dateutil==2.8.1
+    # via
+    #   azure-storage-common
+    #   faker
+python-jose==3.0.1
+    # via django-helusers
+pytz==2019.3
+    # via
+    #   django
+    #   google-api-core
+requests==2.22.0
+    # via
+    #   -r requirements.in
+    #   azure-storage-common
+    #   django-anymail
+    #   django-helusers
+    #   google-api-core
+    #   pyjwkest
+rsa==4.0
+    # via
+    #   google-auth
+    #   python-jose
+rx==1.6.1
+    # via graphql-core
+sentry-sdk==0.12.3
+    # via -r requirements.in
+singledispatch==3.4.0.3
+    # via graphene-django
+six==1.12.0
+    # via
+    #   cryptography
+    #   django-anymail
+    #   django-mailer
+    #   django-parler
+    #   faker
+    #   google-api-core
+    #   google-auth
+    #   google-resumable-media
+    #   graphene
+    #   graphene-django
+    #   graphene-file-upload
+    #   graphql-core
+    #   graphql-relay
+    #   promise
+    #   protobuf
+    #   pyjwkest
+    #   python-dateutil
+    #   python-jose
+    #   singledispatch
+sqlparse==0.3.0
+    # via django
+text-unidecode==1.3
+    # via faker
+unidecode==1.1.1
+    # via graphene-django
+urllib3==1.25.11
+    # via
+    #   requests
+    #   sentry-sdk
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Requirements compiled with pip-tools 5.5 have a sligthly different format than before. This commit does not cause any functional changes.