### PR TITLE
KK-803 | Fix free spot subscription handling in event group

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -493,8 +493,12 @@ class Enrolment(TimestampedModel):
             super().save(*args, **kwargs)
 
             if created:
+                event_group = self.occurrence.event.event_group
+                events = (
+                    event_group.events.all() if event_group else [self.occurrence.event]
+                )
                 self.child.free_spot_notification_subscriptions.filter(
-                    occurrence__event=self.occurrence.event
+                    occurrence__event__in=events
                 ).delete()
 
         if created:

--- a/subscriptions/tests/test_models.py
+++ b/subscriptions/tests/test_models.py
@@ -3,9 +3,14 @@ from datetime import timedelta
 import pytest
 from django.utils.timezone import now
 from subscriptions.factories import FreeSpotNotificationSubscriptionFactory
-from subscriptions.tests.utils import assert_subscriptions
+from subscriptions.tests.utils import assert_child_has_subscriptions
 
-from events.factories import EnrolmentFactory, EventFactory, OccurrenceFactory
+from events.factories import (
+    EnrolmentFactory,
+    EventFactory,
+    EventGroupFactory,
+    OccurrenceFactory,
+)
 
 
 @pytest.mark.django_db
@@ -22,6 +27,43 @@ def test_enrolling_deletes_same_event_free_spot_subscriptions(
     )  # same event subscription
     other_event_subscription = FreeSpotNotificationSubscriptionFactory(child=child)
 
+    # create an enrolment for the child, subscriptions should be updated accordingly
     EnrolmentFactory(occurrence=occurrence_2, child=child)
 
-    assert_subscriptions(child, other_event_subscription)
+    assert_child_has_subscriptions(child, other_event_subscription)
+
+
+@pytest.mark.django_db
+def test_enrolling_deletes_same_event_group_free_spot_subscriptions(child):
+    event_group = EventGroupFactory(published_at=now())
+    event = EventFactory(published_at=now(), event_group=event_group)
+    same_group_event = EventFactory(published_at=now(), event_group=event_group)
+    other_group_event = EventFactory(
+        published_at=now(), event_group=EventGroupFactory()
+    )
+
+    occurrence = OccurrenceFactory.create(time=now() + timedelta(days=1), event=event)
+    same_event_occurrence = OccurrenceFactory.create(
+        time=now() + timedelta(days=2), event=event
+    )
+    same_group_occurrence = OccurrenceFactory(
+        time=now() + timedelta(days=3), event=same_group_event
+    )
+    other_group_occurrence = OccurrenceFactory(
+        time=now() + timedelta(days=4), event=other_group_event
+    )
+
+    same_event_subscription = FreeSpotNotificationSubscriptionFactory(  # noqa: F841
+        child=child, occurrence=same_event_occurrence
+    )
+    same_group_subscription = FreeSpotNotificationSubscriptionFactory(  # noqa: F841
+        child=child, occurrence=same_group_occurrence
+    )
+    other_group_subscription = FreeSpotNotificationSubscriptionFactory(
+        child=child, occurrence=other_group_occurrence
+    )
+
+    # create an enrolment for the child, subscriptions should be updated accordingly
+    EnrolmentFactory(child=child, occurrence=occurrence)
+
+    assert_child_has_subscriptions(child, other_group_subscription)

--- a/subscriptions/tests/test_notifications.py
+++ b/subscriptions/tests/test_notifications.py
@@ -4,7 +4,7 @@ import pytest
 from django.core import mail
 from django.utils.timezone import now
 from subscriptions.factories import FreeSpotNotificationSubscriptionFactory
-from subscriptions.tests.utils import assert_subscriptions
+from subscriptions.tests.utils import assert_child_has_subscriptions
 
 from common.tests.utils import assert_mails_match_snapshot
 from events.factories import EnrolmentFactory, OccurrenceFactory
@@ -42,7 +42,7 @@ def test_free_spot_notification_occurrence_capacity_changes(
 
     assert len(mail.outbox) == 1
     assert_mails_match_snapshot(snapshot)
-    assert_subscriptions(child, other_subscription)
+    assert_child_has_subscriptions(child, other_subscription)
 
 
 @pytest.mark.django_db
@@ -76,7 +76,7 @@ def test_free_spot_notification_event_capacity_changes(
 
     assert len(mail.outbox) == 1
     assert_mails_match_snapshot(snapshot)
-    assert_subscriptions(child, other_subscription)
+    assert_child_has_subscriptions(child, other_subscription)
 
 
 @pytest.mark.django_db
@@ -103,4 +103,4 @@ def test_free_spot_notification_someone_unenrols(
 
     assert len(mail.outbox) == 1
     assert_mails_match_snapshot(snapshot)
-    assert_subscriptions(child, other_subscription)
+    assert_child_has_subscriptions(child, other_subscription)

--- a/subscriptions/tests/utils.py
+++ b/subscriptions/tests/utils.py
@@ -1,7 +1,7 @@
 from collections import Iterable
 
 
-def assert_subscriptions(child, subscriptions):
+def assert_child_has_subscriptions(child, subscriptions):
     if not isinstance(subscriptions, Iterable):
         subscriptions = {subscriptions} if subscriptions else {}
     subscription_ids = {s.pk for s in child.free_spot_notification_subscriptions.all()}


### PR DESCRIPTION
Enrolling to an occurrence should delete all free spot notification subscriptions from the child which are for the same event, or for an event that is in the same event group as the enrolled occurrence.

Before this fix, subscriptions were not deleted from the other events of the event group.