### PR TITLE
Revert "Ignore authentication error like expired JWT from Sentry"

### DIFF
--- a/kukkuu/tests/test_authentication.py
+++ b/kukkuu/tests/test_authentication.py
@@ -65,7 +65,7 @@ def test_authentication_error(live_server):
         ):
             response = graphql_request(live_server)
             assert_match_error_code(response.json(), AUTHENTICATION_ERROR)
-            sentry.assert_not_called()
+            sentry.assert_called()
 
 
 def test_authentication_expired_error(live_server):

--- a/kukkuu/views.py
+++ b/kukkuu/views.py
@@ -99,7 +99,6 @@ sentry_ignored_errors = (
     ObjectDoesNotExist,
     PermissionDenied,
     AuthenticationExpiredError,
-    AuthenticationError,
 )
 
 error_codes = {**error_codes_shared, **error_codes_kukkuu}


### PR DESCRIPTION
Reverts City-of-Helsinki/kukkuu#254

Heard from @tuomas777 that these AuthenticationErrors are in monitoring in purpose, because some real guardians have repeatedly encountered this issue.