### PR TITLE
Removed Translated SMS sender configuration from pipeline

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -61,7 +61,11 @@ jobs:
           K8S_SECRET_MAILER_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
           K8S_SECRET_DEFAULT_FROM_EMAIL: "Kulttuurin kummilapset <noreply@hel.fi>"
           K8S_SECRET_ILMOITIN_TRANSLATED_FROM_EMAIL: "fi=Kulttuurin kummilapset <noreply@hel.fi>,en=Culture Kids <noreply@hel.fi>,sv=Kulturens fadderbarn <noreply@hel.fi>"
-          K8S_SECRET_TRANSLATED_SMS_SENDER: "fi=Kulttuurin kummilapset,en=Culture Kids,sv=Kulturens fadderbarn"
+          # Message sender. International numbers with + or 00 prefix
+          # and 5 to 15 numbers following it, national ones / shortcodes
+          # with 1 to 15 numbers, alphanumeric with max 11 characters.
+          # https://quriiri.fi/wp-content/uploads/2022/03/Quriiri-HTTP-MT-API-v1.pdf
+          # K8S_SECRET_TRANSLATED_SMS_SENDER: "fi=Kulttuurin kummilapset,en=Culture Kids,sv=Kulturens fadderbarn"
           K8S_SECRET_NOTIFICATION_SERVICE_API_TOKEN: ${{ secrets.GH_NS_API_TOKEN_STABLE }}
           K8S_SECRET_NOTIFICATION_SERVICE_API_URL: ${{ secrets.GH_NS_API_URL_STABLE }}
           K8S_SECRET_DEFAULT_FILE_STORAGE: "storages.backends.azure_storage.AzureStorage"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -58,7 +58,11 @@ jobs:
           K8S_SECRET_MAILER_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
           K8S_SECRET_DEFAULT_FROM_EMAIL: "Kulttuurin kummilapset <noreply@hel.fi>"
           K8S_SECRET_ILMOITIN_TRANSLATED_FROM_EMAIL: "fi=Kulttuurin kummilapset <noreply@hel.fi>,en=Culture Kids <noreply@hel.fi>,sv=Kulturens fadderbarn <noreply@hel.fi>"
-          K8S_SECRET_TRANSLATED_SMS_SENDER: "fi=Kulttuurin kummilapset,en=Culture Kids,sv=Kulturens fadderbarn"
+          # Message sender. International numbers with + or 00 prefix
+          # and 5 to 15 numbers following it, national ones / shortcodes
+          # with 1 to 15 numbers, alphanumeric with max 11 characters.
+          # https://quriiri.fi/wp-content/uploads/2022/03/Quriiri-HTTP-MT-API-v1.pdf
+          # K8S_SECRET_TRANSLATED_SMS_SENDER: "fi=Kulttuurin kummilapset,en=Culture Kids,sv=Kulturens fadderbarn"
           K8S_SECRET_NOTIFICATION_SERVICE_API_TOKEN: ${{ secrets.GH_NS_API_TOKEN_STAGING }}
           K8S_SECRET_NOTIFICATION_SERVICE_API_URL: ${{ secrets.GH_NS_API_URL_STAGING }}
           K8S_SECRET_DEFAULT_FILE_STORAGE: "storages.backends.gcloud.GoogleCloudStorage"


### PR DESCRIPTION
The SMS messages sending fails in the notification-service. Maybe the sender name is too long.

<img width="748" alt="image" src="https://user-images.githubusercontent.com/389204/157046894-3efba26f-a4db-4091-83d7-059504890a8a.png">
