### PR TITLE
KK-839 | Add query for child's upcoming events and event groups

### DIFF
--- a/children/schema.py
+++ b/children/schema.py
@@ -48,9 +48,17 @@ class ChildrenConnection(graphene.Connection):
 
 
 class ChildNode(DjangoObjectType):
-    available_events = relay.ConnectionField("events.schema.EventConnection")
+    available_events = relay.ConnectionField(
+        "events.schema.EventConnection",
+        deprecation_reason=(
+            "Doesn't exclude events when yearly limit of enrolments have been exceeded."
+        ),
+    )
     available_events_and_event_groups = relay.ConnectionField(
-        "events.schema.EventOrEventGroupConnection"
+        "events.schema.EventOrEventGroupConnection",
+        deprecation_reason=(
+            "Doesn't exclude events when yearly limit of enrolments have been exceeded."
+        ),
     )
     upcoming_events_and_event_groups = relay.ConnectionField(
         "events.schema.EventOrEventGroupConnection",

--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -553,6 +553,59 @@ snapshots["test_submit_children_and_guardian_with_email 1"] = {
     }
 }
 
+snapshots["test_upcoming_events_and_event_groups 1"] = {
+    "data": {
+        "child": {
+            "upcomingEventsAndEventGroups": {
+                "edges": [
+                    {
+                        "node": {
+                            "__typename": "EventGroupNode",
+                            "canChildEnroll": True,
+                            "name": "This should be the first",
+                        }
+                    },
+                    {
+                        "node": {
+                            "__typename": "EventNode",
+                            "canChildEnroll": True,
+                            "name": "This should be the second",
+                        }
+                    },
+                    {
+                        "node": {
+                            "__typename": "EventGroupNode",
+                            "canChildEnroll": True,
+                            "name": "This should be the third",
+                        }
+                    },
+                    {
+                        "node": {
+                            "__typename": "EventNode",
+                            "canChildEnroll": True,
+                            "name": "This should be the fourth",
+                        }
+                    },
+                    {
+                        "node": {
+                            "__typename": "EventNode",
+                            "canChildEnroll": False,
+                            "name": "Enrolled event",
+                        }
+                    },
+                    {
+                        "node": {
+                            "__typename": "EventGroupNode",
+                            "canChildEnroll": False,
+                            "name": "Event group with one of two events enrolled",
+                        }
+                    },
+                ]
+            }
+        }
+    }
+}
+
 snapshots["test_update_child_mutation 1"] = {
     "data": {
         "updateChild": {

--- a/children/tests/test_api.py
+++ b/children/tests/test_api.py
@@ -1089,7 +1089,9 @@ def test_available_events_and_event_groups(
     OccurrenceFactory(time=future)  # unpublished event
     EnrolmentFactory(
         child=child_with_user_guardian,
-        occurrence=OccurrenceFactory(time=future, event=EventFactory()),
+        occurrence=OccurrenceFactory(
+            time=future, event=EventFactory(published_at=now())
+        ),
     )  # enrolled event
     OccurrenceFactory(event__published_at=now(), time=past)  # event in past
     OccurrenceFactory(

--- a/events/filters.py
+++ b/events/filters.py
@@ -85,6 +85,10 @@ class EventFilter(django_filters.FilterSet):
     available_for_child = django_filters.CharFilter(
         method="filter_by_available_for_child"
     )
+    upcoming = django_filters.BooleanFilter(method="filter_by_upcoming")
+    upcoming_with_leeway = django_filters.BooleanFilter(
+        method="filter_by_upcoming_with_leeway"
+    )
 
     class Meta:
         model = Event
@@ -100,3 +104,13 @@ class EventFilter(django_filters.FilterSet):
         except Child.DoesNotExist:
             return qs
         return qs.available(child)
+
+    def filter_by_upcoming(self, qs, name, value):
+        if value:
+            return qs.upcoming()
+        return qs
+
+    def filter_by_upcoming_with_leeway(self, qs, name, value):
+        if value:
+            return qs.upcoming_with_leeway()
+        return qs

--- a/events/models.py
+++ b/events/models.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from datetime import timedelta
 from typing import Optional
 
@@ -166,6 +167,14 @@ class EventQueryset(TranslatableQuerySet):
             * the child must not have enrolled to any event in the same event group
               as the event
         """
+
+        warnings.warn(
+            "Query doesn't exclude events when yearly "
+            "limit of enrolments have been exceeded.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         child_enrolled_event_groups = EventGroup.objects.filter(
             events__occurrences__in=child.occurrences.all()
         )

--- a/events/schema.py
+++ b/events/schema.py
@@ -244,8 +244,8 @@ class EventNode(DjangoObjectType):
         child_id = get_node_id_from_global_id(kwargs["child_id"], "ChildNode")
         try:
             child = Child.objects.user_can_view(info.context.user).get(id=child_id)
-        except Child.DoesNotExist:
-            return None
+        except Child.DoesNotExist as e:
+            raise ObjectDoesNotExistError(e)
         return self.can_child_enroll(child)
 
 
@@ -316,8 +316,8 @@ class EventGroupNode(DjangoObjectType):
         child_id = get_node_id_from_global_id(kwargs["child_id"], "ChildNode")
         try:
             child = Child.objects.user_can_view(info.context.user).get(id=child_id)
-        except Child.DoesNotExist:
-            return None
+        except Child.DoesNotExist as e:
+            raise ObjectDoesNotExistError(e)
         return self.can_child_enroll(child)
 
 

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -524,6 +524,46 @@ snapshots["test_events_and_event_groups_query_project_user 1"] = {
     }
 }
 
+snapshots["test_events_and_event_groups_query_upcoming_filter[False-False] 1"] = {
+    "data": {
+        "eventsAndEventGroups": {
+            "edges": [{"node": {"__typename": "EventNode", "name": "In the future"}}]
+        }
+    }
+}
+
+snapshots["test_events_and_event_groups_query_upcoming_filter[False-True] 1"] = {
+    "data": {
+        "eventsAndEventGroups": {
+            "edges": [
+                {"node": {"__typename": "EventGroupNode", "name": "In the future"}}
+            ]
+        }
+    }
+}
+
+snapshots["test_events_and_event_groups_query_upcoming_filter[True-False] 1"] = {
+    "data": {
+        "eventsAndEventGroups": {
+            "edges": [
+                {"node": {"__typename": "EventNode", "name": "Within leeway"}},
+                {"node": {"__typename": "EventNode", "name": "In the future"}},
+            ]
+        }
+    }
+}
+
+snapshots["test_events_and_event_groups_query_upcoming_filter[True-True] 1"] = {
+    "data": {
+        "eventsAndEventGroups": {
+            "edges": [
+                {"node": {"__typename": "EventGroupNode", "name": "Within leeway"}},
+                {"node": {"__typename": "EventGroupNode", "name": "In the future"}},
+            ]
+        }
+    }
+}
+
 snapshots["test_events_query_normal_user 1"] = {
     "data": {
         "events": {


### PR DESCRIPTION
This PR adds an API to query all upcoming events and event groups for a child (`ChildNode.upcomingEventsAndEventGroups`). As opposed to the `availableEventsAndEventGroups` the new query also includes upcoming events to which the child might not be eligible to enroll.

`EventGroupNode` and `EventNode` include a new field `canChildEnroll(childId: ID)` which indicates if enrolling to the event is possible for the given child.