### PR TITLE
KK-885 | Republish an event group

### DIFF
--- a/events/schema.py
+++ b/events/schema.py
@@ -309,7 +309,7 @@ class EventGroupNode(DjangoObjectType):
     def get_node(cls, info, id):
         return super().get_node(info, id)
 
-    def resolve_translations(self, info, **kwargs):
+    def resolve_translations(self: EventGroup, info, **kwargs):
         return self.translations.order_by("language_code")
 
     def resolve_can_child_enroll(self: EventGroup, info, **kwargs) -> Optional[bool]:
@@ -976,7 +976,8 @@ class PublishEventGroupMutation(graphene.relay.ClientIDMutation):
         if not event_group.can_user_publish(user):
             raise PermissionDenied("No permission to publish the event group.")
 
-        if event_group.is_published():
+        if event_group.is_published() and not event_group.events.unpublished().exists():
+            # Republishing an event group is allowed if new unpublished events exist
             raise EventGroupAlreadyPublishedError("Event group is already published")
 
         try:

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -1197,6 +1197,38 @@ snapshots["test_publish_ticketmaster_event[object_perm-False] 1"] = {
     "data": {"publishEvent": {"event": {"publishedAt": "2020-12-12T00:00:00+00:00"}}}
 }
 
+snapshots["test_republish_event_group[model_perm-True] 1"] = {
+    "data": {
+        "publishEventGroup": {
+            "eventGroup": {
+                "events": {
+                    "edges": [
+                        {"node": {"publishedAt": "2020-12-11T00:00:00+00:00"}},
+                        {"node": {"publishedAt": "2020-12-12T00:00:00+00:00"}},
+                    ]
+                },
+                "publishedAt": "2020-12-12T00:00:00+00:00",
+            }
+        }
+    }
+}
+
+snapshots["test_republish_event_group[object_perm-True] 1"] = {
+    "data": {
+        "publishEventGroup": {
+            "eventGroup": {
+                "events": {
+                    "edges": [
+                        {"node": {"publishedAt": "2020-12-11T00:00:00+00:00"}},
+                        {"node": {"publishedAt": "2020-12-12T00:00:00+00:00"}},
+                    ]
+                },
+                "publishedAt": "2020-12-12T00:00:00+00:00",
+            }
+        }
+    }
+}
+
 snapshots["test_required_translation 1"] = {
     "data": {
         "addEvent": {

--- a/events/tests/snapshots/snap_test_notifications.py
+++ b/events/tests/snapshots/snap_test_notifications.py
@@ -16,6 +16,17 @@ snapshots["test_event_group_publish_notification 1"] = [
 """
 ]
 
+snapshots["test_event_group_republish_notification 1"] = [
+    """kukkuu@example.com|['tonya77@example.com']|Event group published FI|
+        Event group FI: Alone our very television beat at success.
+        Guardian FI: Samantha Bryant (tonya77@example.com)
+        Url: http://localhost:3000/fi/profile/child/Q2hpbGROb2RlOjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDMwOQ==/event-group/RXZlbnRHcm91cE5vZGU6Nzc3
+        Events:
+            Girl middle same space speak. 2020-12-12 00:00:00+00:00 http://localhost:3000/fi/profile/child/Q2hpbGROb2RlOjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDMwOQ==/event/RXZlbnROb2RlOjc3OA==
+            Base may middle good father boy economy. 2020-12-11 00:00:00+00:00 http://localhost:3000/fi/profile/child/Q2hpbGROb2RlOjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDMwOQ==/event/RXZlbnROb2RlOjc3Nw==
+"""
+]
+
 snapshots["test_feedback_notification 1"] = [
     """kukkuu@example.com|['tonya77@example.com']|Feedback FI|
         Event FI: Answer entire increase thank certainly again thought.

--- a/events/tests/test_notifications.py
+++ b/events/tests/test_notifications.py
@@ -171,13 +171,43 @@ def test_event_group_publish_notification(
     snapshot,
     notification_template_event_published_fi,
     notification_template_event_group_published_fi,
+    project,
     another_project,
 ):
-    ChildWithGuardianFactory(id=777)
+    ChildWithGuardianFactory(id=777, project=project)
     ChildWithGuardianFactory(project=another_project)
     event = EventFactory(id=777, event_group=EventGroupFactory(id=777))
 
     event.event_group.publish()
+
+    assert_mails_match_snapshot(snapshot)
+
+
+@pytest.mark.django_db
+def test_event_group_republish_notification(
+    snapshot,
+    notification_template_event_published_fi,
+    notification_template_event_group_published_fi,
+    project,
+    another_project,
+    past,
+):
+    ChildWithGuardianFactory(id=777, project=project)
+    ChildWithGuardianFactory(project=another_project)
+    event_group = EventGroupFactory(id=777, published_at=past)
+    EventFactory(
+        id=777,
+        event_group=event_group,
+        ready_for_event_group_publishing=True,
+        published_at=past,
+    )
+    EventFactory(
+        id=778,
+        event_group=event_group,
+        ready_for_event_group_publishing=True,
+    )
+
+    event_group.publish()
 
     assert_mails_match_snapshot(snapshot)
 


### PR DESCRIPTION
Event group can be republished if there are new unpublished events in the event group which are marked ready for event group publishing.