### PR TITLE
 KK-892 KK-911 | Ticket QR code is valid for the whole day

### DIFF
--- a/events/tests/test_ticket_service.py
+++ b/events/tests/test_ticket_service.py
@@ -1,7 +1,8 @@
-from datetime import timedelta
+from datetime import datetime
 
 import pytest
 from django.utils import timezone
+from freezegun import freeze_time
 
 from events.factories import EnrolmentFactory, OccurrenceFactory
 from events.ticket_service import check_ticket_validity
@@ -11,19 +12,25 @@ from kukkuu.exceptions import (
 )
 
 
+@freeze_time("2020-11-11 12:00:00")
+@pytest.mark.parametrize(
+    "occurrence_time, expected",
+    [
+        (datetime(2020, 11, 11, 12, tzinfo=timezone.now().tzinfo), True),  # Present
+        (datetime(2020, 11, 11, 13, tzinfo=timezone.now().tzinfo), True),  # +1h
+        (datetime(2020, 11, 11, 11, tzinfo=timezone.now().tzinfo), True),  # -1h
+        (datetime(2020, 11, 13, 12, tzinfo=timezone.now().tzinfo), True),  # +1d
+        (datetime(2020, 11, 10, 12, tzinfo=timezone.now().tzinfo), False),  # -1d
+    ],
+)
 @pytest.mark.django_db
-def test_check_ticket_validity():
-    upcoming_occurrence = OccurrenceFactory(time=timezone.now() + timedelta(days=1))
-    valid_enrolment = EnrolmentFactory(occurrence=upcoming_occurrence)
-    enrolment, validity = check_ticket_validity(valid_enrolment.reference_id)
-    assert enrolment == valid_enrolment
-    assert validity is True
-
-    past_occurrence = OccurrenceFactory(time=timezone.now() - timedelta(days=1))
-    invalid_enrolment = EnrolmentFactory(occurrence=past_occurrence)
-    enrolment, validity = check_ticket_validity(invalid_enrolment.reference_id)
-    assert enrolment == invalid_enrolment
-    assert validity is False
+def test_check_ticket_validity(project, occurrence_time, expected):
+    """Tickets are show valid for the whole day on the occurrence day."""
+    occurrence = OccurrenceFactory(time=occurrence_time)
+    expected_enrolment = EnrolmentFactory(occurrence=occurrence)
+    enrolment, validity = check_ticket_validity(expected_enrolment.reference_id)
+    assert enrolment == expected_enrolment
+    assert validity is expected
 
 
 @pytest.mark.django_db

--- a/events/ticket_service.py
+++ b/events/ticket_service.py
@@ -1,5 +1,7 @@
 from typing import Tuple
 
+from django.utils import timezone
+
 from events.models import Enrolment
 from kukkuu.exceptions import EnrolmentReferenceIdDoesNotExist
 
@@ -17,4 +19,6 @@ def check_ticket_validity(enrolment_reference_id: str) -> Tuple[Enrolment, bool]
         raise EnrolmentReferenceIdDoesNotExist(
             "The decoded reference id does not match to any of the existing enrolments"
         )
-    return (enrolment, enrolment.is_upcoming())
+
+    valid = enrolment.occurrence.time.date() >= timezone.localdate()
+    return enrolment, valid


### PR DESCRIPTION
This PR changes the QR code validation so that the ticket will appear to be valid for the whole day of the event occurrence.