### PR TITLE
KK-893 KK-890 | Count ticket system passwords towards yearly enrolment limit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.6.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8

--- a/children/models.py
+++ b/children/models.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.core.validators import RegexValidator
 from django.db import models, transaction
 from django.db.models import Q
@@ -80,7 +82,7 @@ class Child(UUIDPrimaryKeyModel, TimestampedModel):
     def can_user_administer(self, user):
         return user.can_administer_project(self.project)
 
-    def get_enrolment_count(self, year: int = None, past=False):
+    def get_enrolment_count(self, year: Optional[int] = None, past=False):
         if year and past:
             raise ValueError("Cannot use year and past arguments at the same time.")
         now = timezone.now()

--- a/children/models.py
+++ b/children/models.py
@@ -79,16 +79,6 @@ class Child(UUIDPrimaryKeyModel, TimestampedModel):
     def can_user_administer(self, user):
         return user.can_administer_project(self.project)
 
-    def get_or_assign_ticketmaster_password(self, event):
-        from events.models import TicketSystemPassword
-
-        try:
-            self.ticket_system_passwords.get(event=event).value
-        except TicketSystemPassword.DoesNotExist:
-            return TicketSystemPassword.objects.assign_to_child(
-                event=event, child=self
-            ).value
-
 
 class RelationshipQuerySet(models.QuerySet):
     def user_can_view(self, user):

--- a/children/schema.py
+++ b/children/schema.py
@@ -113,13 +113,11 @@ class ChildNode(DjangoObjectType):
             return None
 
     def resolve_enrolment_count(self: Child, info, **kwargs):
-        year = kwargs.get("year") or timezone.now().year
-        return self.occurrences.filter(time__year=year).count()
+        year = kwargs.get("year")
+        return self.get_enrolment_count(year)
 
     def resolve_past_enrolment_count(self: Child, info, **kwargs):
-        return self.occurrences.filter(
-            time__year=timezone.now().year, time__lt=timezone.now()
-        ).count()
+        return self.get_enrolment_count(past=True)
 
     def resolve_past_events(self: Child, info, **kwargs):
         """

--- a/children/tests/test_api.py
+++ b/children/tests/test_api.py
@@ -169,7 +169,7 @@ def test_submit_children_and_guardian_unauthenticated(api_client):
     assert_permission_denied(executed)
 
 
-def test_submit_children_and_guardian(snapshot, user_api_client, languages):
+def test_submit_children_and_guardian(snapshot, user_api_client, languages, project):
     variables = deepcopy(SUBMIT_CHILDREN_AND_GUARDIAN_VARIABLES)
     variables["input"]["guardian"]["languagesSpokenAtHome"] = [
         get_global_id(language) for language in languages[0:2]
@@ -192,7 +192,7 @@ def test_submit_children_and_guardian(snapshot, user_api_client, languages):
         assert_relationship_matches_data(relationship, child_data.get("relationship"))
 
 
-def test_submit_children_and_guardian_with_email(snapshot, user_api_client):
+def test_submit_children_and_guardian_with_email(snapshot, user_api_client, project):
     variables = deepcopy(SUBMIT_CHILDREN_AND_GUARDIAN_VARIABLES)
     variables["input"]["guardian"]["email"] = "updated_email@example.com"
 
@@ -542,7 +542,7 @@ ADD_CHILD_VARIABLES = {
 }
 
 
-def test_add_child_mutation(snapshot, guardian_api_client):
+def test_add_child_mutation(snapshot, guardian_api_client, project):
     executed = guardian_api_client.execute(
         ADD_CHILD_MUTATION, variables=ADD_CHILD_VARIABLES
     )

--- a/events/models.py
+++ b/events/models.py
@@ -488,14 +488,15 @@ class Occurrence(TimestampedModel):
         except AttributeError:
             return self.enrolments.count()
 
-    def get_capacity(self):
+    def get_capacity(self) -> Optional[int]:
         if self.capacity_override is not None:
             return self.capacity_override
         else:
             return self.event.capacity_per_occurrence
 
-    def get_remaining_capacity(self):
-        return max(self.get_capacity() - self.get_enrolment_count(), 0)
+    def get_remaining_capacity(self) -> int:
+        capacity = self.get_capacity() or 0
+        return max(capacity - self.get_enrolment_count(), 0)
 
     def can_user_administer(self, user):
         # There shouldn't ever be a situation where event.project != venue.project

--- a/events/models.py
+++ b/events/models.py
@@ -85,7 +85,7 @@ class EventGroup(TimestampedModel, TranslatableModel):
     def can_user_publish(self, user):
         return user.can_publish_in_project(self.project)
 
-    def can_child_enroll(self, child) -> bool:
+    def can_child_enroll(self, child: Child) -> bool:
         """Check if the child can enroll to an event in the event group."""
 
         if not self.is_published():
@@ -97,13 +97,13 @@ class EventGroup(TimestampedModel, TranslatableModel):
         else:
             return False
 
-        if (
-            child.occurrences.filter(time__year=year).count()
-            >= child.project.enrolment_limit
-        ):
+        if child.get_enrolment_count(year=year) >= child.project.enrolment_limit:
             return False
 
         if child.occurrences.filter(event__event_group=self).exists():
+            return False
+
+        if child.ticket_system_passwords.filter(event__event_group=self).exists():
             return False
 
         return True
@@ -151,7 +151,7 @@ class EventQueryset(TranslatableQuerySet):
 
     def available(self, child):
         """
-        A child's available events must match all of the following rules:
+        A child's available events must match all the following rules:
             * the event must be published
             * the event must have at least one occurrence in the future
             * the child must not have enrolled to the event
@@ -308,13 +308,13 @@ class Event(TimestampedModel, TranslatableModel):
         if self.event_group and not self.event_group.can_child_enroll(child):
             return False
 
-        if (
-            child.occurrences.filter(time__year=year).count()
-            >= child.project.enrolment_limit
-        ):
+        if child.get_enrolment_count(year=year) >= child.project.enrolment_limit:
             return False
 
         if child.occurrences.filter(event=self).exists():
+            return False
+
+        if child.ticket_system_passwords.filter(event=self).exists():
             return False
 
         return True

--- a/events/schema.py
+++ b/events/schema.py
@@ -78,7 +78,7 @@ def validate_enrolment(child, occurrence):
         raise PastOccurrenceError("Cannot join occurrence in the past")
 
     if (
-        child.occurrences.filter(time__year=occurrence.time.year).count()
+        child.get_enrolment_count(year=occurrence.time.year)
         >= occurrence.event.project.enrolment_limit
     ):
         raise IneligibleOccurrenceEnrolment("Yearly enrolment limit has been reached")

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -133,7 +133,7 @@ snapshots["test_delete_event_group[object_perm] 1"] = {
     "data": {"deleteEventGroup": {"__typename": "DeleteEventGroupMutationPayload"}}
 }
 
-snapshots["test_enrol_limit_reached[0-False] 1"] = {
+snapshots["test_enrol_limit_reached[False-0-False] 1"] = {
     "data": {
         "enrolOccurrence": {
             "enrolment": {
@@ -145,7 +145,31 @@ snapshots["test_enrol_limit_reached[0-False] 1"] = {
     }
 }
 
-snapshots["test_enrol_limit_reached[1-False] 1"] = {
+snapshots["test_enrol_limit_reached[False-1-False] 1"] = {
+    "data": {
+        "enrolOccurrence": {
+            "enrolment": {
+                "child": {"firstName": "Brandon"},
+                "createdAt": "2020-11-11T00:00:00+00:00",
+                "occurrence": {"time": "2020-11-11T00:00:00+00:00"},
+            }
+        }
+    }
+}
+
+snapshots["test_enrol_limit_reached[True-0-False] 1"] = {
+    "data": {
+        "enrolOccurrence": {
+            "enrolment": {
+                "child": {"firstName": "Brandon"},
+                "createdAt": "2020-11-11T00:00:00+00:00",
+                "occurrence": {"time": "2020-11-11T00:00:00+00:00"},
+            }
+        }
+    }
+}
+
+snapshots["test_enrol_limit_reached[True-1-False] 1"] = {
     "data": {
         "enrolOccurrence": {
             "enrolment": {

--- a/messaging/tests/test_sending.py
+++ b/messaging/tests/test_sending.py
@@ -72,7 +72,9 @@ def test_cannot_send_message_again_without_force(snapshot, message):
         "occurrence_yesterday_1",
     ),
 )
-def test_message_sending_with_filters(snapshot, recipient_selection, event_selection):
+def test_message_sending_with_filters(
+    snapshot, recipient_selection, event_selection, project
+):
     """Ridiculously complex filtering test
 
     There are three events:
@@ -209,7 +211,9 @@ def test_message_sending_with_filters(snapshot, recipient_selection, event_selec
 
 @freeze_time("2020-11-11")
 @pytest.mark.parametrize("upcoming_occurrence", (True, False))
-def test_message_sending_to_invited_group_and_event_groups(upcoming_occurrence):
+def test_message_sending_to_invited_group_and_event_groups(
+    upcoming_occurrence, project
+):
     """Sending message to invited group when an event group has to be considered.
 
     Event group consists of two events, with one occurrence each:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ attrs==21.2.0
     #   pytest
 backcall==0.2.0
     # via ipython
-black==21.9b0
+black==22.6.0
     # via -r requirements-dev.in
 certifi==2021.10.8
     # via
@@ -22,7 +22,7 @@ charset-normalizer==2.0.6
     # via
     #   -c requirements.txt
     #   requests
-click==8.0.3
+click==8.1.3
     # via black
 coverage[toml]==6.0.1
     # via pytest-cov
@@ -64,7 +64,7 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-platformdirs==2.4.0
+platformdirs==2.5.2
     # via black
 pluggy==1.0.0
     # via pytest
@@ -97,8 +97,6 @@ python-dateutil==2.8.2
     # via
     #   -c requirements.txt
     #   freezegun
-regex==2021.10.8
-    # via black
 requests==2.26.0
     # via
     #   -c requirements.txt
@@ -117,7 +115,7 @@ termcolor==1.1.0
     # via snapshottest
 toml==0.10.2
     # via pytest
-tomli==1.2.1
+tomli==2.0.1
     # via
     #   black
     #   coverage
@@ -125,7 +123,7 @@ traitlets==5.1.0
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==3.10.0.2
+typing-extensions==4.3.0
     # via black
 urllib3==1.26.7
     # via


### PR DESCRIPTION
This PR adds some functionality related to counting TicketSystemPasswords as enrolments.

- Move enrollment count calculation to the Child model
- `TicketSystemPassword` instance is counted as an enrollment (when requesting the amount of enrollments for a child)
- `Event/EventGroup.can_child_enroll` and `validate_enrolment` will respond as expected when the enrolment has been done using a TicketSystemPassword instance.

Extra:
- Bump black