### PR TITLE
KK-948 | Remove side-effects from TicketSystemPassword query

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -341,12 +341,6 @@ class Event(TimestampedModel, TranslatableModel):
     def is_published(self):
         return bool(self.published_at)
 
-    def get_or_assign_ticket_system_password(self, child):
-        try:
-            return self.ticket_system_passwords.get(child=child).value
-        except TicketSystemPassword.DoesNotExist:
-            return TicketSystemPassword.objects.assign(self, child).value
-
 
 class OccurrenceQueryset(models.QuerySet):
     def user_can_view(self, user):

--- a/events/schema.py
+++ b/events/schema.py
@@ -143,7 +143,7 @@ class EventTicketSystem(graphene.Interface):
 
 
 class TicketmasterEventTicketSystem(ObjectType):
-    child_password = graphene.String(child_id=graphene.ID(required=True), required=True)
+    child_password = graphene.String(child_id=graphene.ID())
     free_password_count = graphene.Int(required=True)
     used_password_count = graphene.Int(required=True)
 
@@ -156,7 +156,9 @@ class TicketmasterEventTicketSystem(ObjectType):
                 id=get_node_id_from_global_id(kwargs["child_id"], "ChildNode")
             )
             return event.ticket_system_passwords.get(child=child).value
-        except (Child.DoesNotExist, TicketSystemPassword.DoesNotExist) as e:
+        except TicketSystemPassword.DoesNotExist:
+            return None
+        except Child.DoesNotExist as e:
             raise ObjectDoesNotExistError(e)
 
     def resolve_free_password_count(self, info, **kwargs):

--- a/events/schema.py
+++ b/events/schema.py
@@ -150,18 +150,14 @@ class TicketmasterEventTicketSystem(ObjectType):
     class Meta:
         interfaces = (EventTicketSystem,)
 
-    def resolve_child_password(self, info, **kwargs):
+    def resolve_child_password(event: Event, info, **kwargs):
         try:
             child = Child.objects.user_can_view(info.context.user).get(
                 id=get_node_id_from_global_id(kwargs["child_id"], "ChildNode")
             )
-        except Child.DoesNotExist as e:
+            return event.ticket_system_passwords.get(child=child).value
+        except (Child.DoesNotExist, TicketSystemPassword.DoesNotExist) as e:
             raise ObjectDoesNotExistError(e)
-
-        try:
-            return self.get_or_assign_ticket_system_password(child)
-        except NoFreePasswordsError as e:
-            raise NoFreeTicketSystemPasswordsError(e)
 
     def resolve_free_password_count(self, info, **kwargs):
         if not self.can_user_administer(info.context.user):

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -437,18 +437,7 @@ Agree room laugh prevent make. Our very television beat at success decade.""",
     }
 }
 
-snapshots["test_event_ticket_system_password_assignation 1"] = {
-    "data": {
-        "event": {
-            "ticketSystem": {
-                "childPassword": "the correct password",
-                "type": "TICKETMASTER",
-            }
-        }
-    }
-}
-
-snapshots["test_event_ticket_system_password_assignation 2"] = {
+snapshots["test_event_ticket_system_password_own_child_password_exists 1"] = {
     "data": {
         "event": {
             "ticketSystem": {

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -2515,50 +2515,15 @@ query TicketSystemChildPassword($eventId: ID!, $childId: ID!) {
 """
 
 
-def test_event_ticket_system_password_assignation(snapshot, guardian_api_client):
-    event = EventFactory(ticket_system=Event.TICKETMASTER, published_at=now())
-    child = ChildWithGuardianFactory(
-        relationship__guardian__user=guardian_api_client.user.guardian.user
-    )
-    someone_elses_password = TicketSystemPasswordFactory(  # noqa: F841
-        event=event, value="FATAL LEAK"
-    )
-    free_password = TicketSystemPasswordFactory(  # noqa: F841
-        event=event, child=None, value="the correct password"
-    )
-    another_free_password = TicketSystemPasswordFactory(  # noqa: F841
-        event=event, child=None, value="wrong password"
-    )
-
-    variables = {"eventId": get_global_id(event), "childId": get_global_id(child)}
-
-    executed = guardian_api_client.execute(
-        EVENT_TICKET_SYSTEM_PASSWORD_QUERY,
-        variables=variables,
-    )
-
-    snapshot.assert_match(executed)
-    assert child.ticket_system_passwords.get(event=event) == free_password
-
-    # second query should yield the same results
-    executed = guardian_api_client.execute(
-        EVENT_TICKET_SYSTEM_PASSWORD_QUERY,
-        variables=variables,
-    )
-
-    snapshot.assert_match(executed)
-    assert child.ticket_system_passwords.get(event=event) == free_password
-
-
-def test_event_ticket_system_password_assignation_no_free_passwords(
-    guardian_api_client,
+def test_event_ticket_system_password_own_child_password_exists(
+    snapshot, guardian_api_client
 ):
     event = EventFactory(ticket_system=Event.TICKETMASTER, published_at=now())
     child = ChildWithGuardianFactory(
         relationship__guardian__user=guardian_api_client.user.guardian.user
     )
-    someone_elses_password = TicketSystemPasswordFactory(  # noqa: F841
-        event=event, value="FATAL LEAK"
+    existing_password = TicketSystemPasswordFactory(
+        event=event, child=child, value="the correct password"
     )
 
     variables = {"eventId": get_global_id(event), "childId": get_global_id(child)}
@@ -2568,7 +2533,25 @@ def test_event_ticket_system_password_assignation_no_free_passwords(
         variables=variables,
     )
 
-    assert_match_error_code(executed, NO_FREE_TICKET_SYSTEM_PASSWORDS_ERROR)
+    snapshot.assert_match(executed)
+    assert child.ticket_system_passwords.get(event=event) == existing_password
+
+
+def test_event_ticket_system_password_own_child_no_password(guardian_api_client):
+    event = EventFactory(ticket_system=Event.TICKETMASTER, published_at=now())
+    child = ChildWithGuardianFactory(
+        relationship__guardian__user=guardian_api_client.user.guardian.user
+    )
+
+    variables = {"eventId": get_global_id(event), "childId": get_global_id(child)}
+
+    executed = guardian_api_client.execute(
+        EVENT_TICKET_SYSTEM_PASSWORD_QUERY,
+        variables=variables,
+    )
+
+    assert_match_error_code(executed, OBJECT_DOES_NOT_EXIST_ERROR)
+    assert not child.ticket_system_passwords.filter(event=event).exists()
 
 
 def test_event_ticket_system_password_not_own_child(guardian_api_client):


### PR DESCRIPTION
**WAITING FOR FRONTEND CHANGES BEFORE MERGING!**

## Description

Previously TicketSystemPassword query acted as mutation on the first
query run. Remove the mutation functionality from the query altogether.

Add test cases:
 - test_event_ticket_system_password_own_child_password_exists
 - test_event_ticket_system_password_own_child_no_password

Remove as unnecessary:
 - Event.get_or_assign_ticket_system_password function
 - test_event_ticket_system_password_assignation test
 - test_event_ticket_system_password_assignation_no_free_passwords test

## Context

[KK-948](https://helsinkisolutionoffice.atlassian.net/browse/KK-948)

Before merging frontend should be updated first to use the AssignTicketSystemPasswordMutation from PR #289.