### PR TITLE
KK-950 | Implement GraphQL query for fetching a child's all internal and external enrolments

### DIFF
--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -6,6 +6,43 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots["test_active_internal_and_ticketmaster_enrolments 1"] = {
+    "data": {
+        "child": {
+            "activeInternalAndTicketSystemEnrolments": {
+                "edges": [
+                    {
+                        "node": {
+                            "__typename": "TicketmasterEnrolmentNode",
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "event": {"name": "1/4"},
+                        }
+                    },
+                    {
+                        "node": {
+                            "__typename": "EnrolmentNode",
+                            "occurrence": {"event": {"name": "2/4"}},
+                        }
+                    },
+                    {
+                        "node": {
+                            "__typename": "TicketmasterEnrolmentNode",
+                            "createdAt": "2020-12-12T00:00:00+00:00",
+                            "event": {"name": "3/4"},
+                        }
+                    },
+                    {
+                        "node": {
+                            "__typename": "EnrolmentNode",
+                            "occurrence": {"event": {"name": "4/4"}},
+                        }
+                    },
+                ]
+            }
+        }
+    }
+}
+
 snapshots["test_add_child_mutation 1"] = {
     "data": {
         "addChild": {

--- a/events/schema.py
+++ b/events/schema.py
@@ -328,14 +328,14 @@ class EventGroupNode(DjangoObjectType):
         return self.can_child_enroll(child)
 
 
-class EventOrEventGroup(graphene.Union):
+class EventOrEventGroupUnion(graphene.Union):
     class Meta:
         types = (EventNode, EventGroupNode)
 
 
 class EventOrEventGroupConnection(Connection):
     class Meta:
-        node = EventOrEventGroup
+        node = EventOrEventGroupUnion
 
 
 class EventGroupConnection(Connection):

--- a/events/schema.py
+++ b/events/schema.py
@@ -6,7 +6,7 @@ import graphene
 from django.apps import apps
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
-from django.db.models import Count, Prefetch
+from django.db.models import Count, Prefetch, Q
 from django.utils import timezone
 from django.utils.translation import get_language
 from graphene import Connection, ObjectType, relay
@@ -469,6 +469,36 @@ class EnrolmentNode(DjangoObjectType):
 
     def resolve_reference_id(self, info, **kwargs):
         return self.reference_id
+
+
+class TicketmasterEnrolmentNode(DjangoObjectType):
+    created_at = graphene.DateTime(required=True)
+
+    class Meta:
+        model = TicketSystemPassword
+        interfaces = (relay.Node,)
+        fields = ("event", "created_at")
+
+    @classmethod
+    @login_required
+    def get_queryset(cls, queryset, info):
+        return queryset.filter(
+            Q(child__guardians__user=info.context.user)
+            | Q(child__project__in=info.context.user.administered_projects)
+        ).distinct()
+
+    def resolve_created_at(self, info):
+        return self.assigned_at
+
+
+class InternalOrTicketSystemEnrolmentUnion(graphene.Union):
+    class Meta:
+        types = (EnrolmentNode, TicketmasterEnrolmentNode)
+
+
+class InternalOrTicketSystemEnrolmentConnection(Connection):
+    class Meta:
+        node = InternalOrTicketSystemEnrolmentUnion
 
 
 class TicketVerificationNode(ObjectType):


### PR DESCRIPTION
Implemented query for fetching upcoming internal ticket system
enrolments (`Enrolment` model instances) and external ticket system
"enrolments" (assigned `TicketSystemPassword` instances). The enrolments
are sorted from earliest to latest where time is either the related
occurrence's time or the related event's latest occurrence's time
depending on which kind of enrolment it is.

The current purpose of this query is to provide a way for the UI to
fetch a child's all upcoming enrolments to "Tulevat tapahtumasi" (your
upcoming events) section in child profile view.

Example request:
```graphql
query ChildEnrolments {
  child(id: "Q2hpbGROb2RlOjJhYzY1MjE3LWNhZDktNDhlNi05ZWVhLTNjMWIwODhhOTIyZA==") {
    activeInternalAndTicketSystemEnrolments {
      edges {
        node {
          __typename
          ... on TicketmasterEnrolmentNode {
            createdAt
            event {
              name
            }
          }
          ... on EnrolmentNode {
            created_at
            occurrence {
              event {
		name
              }
            }
          }
        }
      }
    }
  }
}
```

Example response:
```json
{
  "data": {
    "child": {
      "activeInternalAndTicketSystemEnrolments": {
        "edges": [
          {
            "node": {
              "__typename": "EnrolmentNode",
              "createdAt": "2022-08-31T21:29:45.267373+00:00",
              "occurrence": {
                "event": {
                  "name": "Tapahtumien kuningas"
                }
              }
            }
          },
          {
            "node": {
              "__typename": "TicketmasterEnrolmentNode",
              "createdAt": "2022-08-11T12:09:13.819485+00:00",
              "event": {
                "name": "Toinen huikea tapahtuma"
              }
            }
          }
        ]
      }
    }
  }
}
```
