### PR TITLE
KK-914 | Add ticket system password counts to event API

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -732,6 +732,9 @@ class TicketSystemPasswordQueryset(models.QuerySet):
     def free(self):
         return self.filter(child=None)
 
+    def used(self):
+        return self.exclude(child=None)
+
     @transaction.atomic
     def assign(self, event: Event, child: Child) -> "TicketSystemPassword":
         obj: TicketSystemPassword = (

--- a/events/schema.py
+++ b/events/schema.py
@@ -144,6 +144,8 @@ class EventTicketSystem(graphene.Interface):
 
 class TicketmasterEventTicketSystem(ObjectType):
     child_password = graphene.String(child_id=graphene.ID(required=True), required=True)
+    free_password_count = graphene.Int(required=True)
+    used_password_count = graphene.Int(required=True)
 
     class Meta:
         interfaces = (EventTicketSystem,)
@@ -160,6 +162,16 @@ class TicketmasterEventTicketSystem(ObjectType):
             return self.get_or_assign_ticket_system_password(child)
         except NoFreePasswordsError as e:
             raise NoFreeTicketSystemPasswordsError(e)
+
+    def resolve_free_password_count(self, info, **kwargs):
+        if not self.can_user_administer(info.context.user):
+            raise PermissionDenied()
+        return self.ticket_system_passwords.free().count()
+
+    def resolve_used_password_count(self, info, **kwargs):
+        if not self.can_user_administer(info.context.user):
+            raise PermissionDenied()
+        return self.ticket_system_passwords.used().count()
 
 
 class InternalEventTicketSystem(ObjectType):

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -459,6 +459,12 @@ snapshots["test_event_ticket_system_password_assignation 2"] = {
     }
 }
 
+snapshots["test_event_ticket_system_password_counts 1"] = {
+    "data": {
+        "event": {"ticketSystem": {"freePasswordCount": 3, "usedPasswordCount": 2}}
+    }
+}
+
 snapshots["test_events_and_event_groups_query_normal_user 1"] = {
     "data": {
         "eventsAndEventGroups": {


### PR DESCRIPTION
Example query:
```graphql
event(id: "RXZlbnROb2RlOjI=") {
  name
  ticketSystem {
    ... on TicketmasterEventTicketSystem {
      freePasswordCount
      usedPasswordCount
    }
  }
}
```

Example response:
```json
{
  "data": {
    "event": {
      "name": "Parikoodauksen alkeet",
      "ticketSystem": {
        "freePasswordCount": 3,
        "usedPasswordCount": 2
      }
    }
  }
}
```