### PR TITLE
KK-948 | Tweak ticket system password query

### DIFF
--- a/events/schema.py
+++ b/events/schema.py
@@ -142,7 +142,7 @@ class EventTicketSystem(graphene.Interface):
 
 
 class TicketmasterEventTicketSystem(ObjectType):
-    child_password = graphene.String(child_id=graphene.ID(required=True), required=True)
+    child_password = graphene.String(child_id=graphene.ID())
 
     class Meta:
         interfaces = (EventTicketSystem,)
@@ -153,7 +153,9 @@ class TicketmasterEventTicketSystem(ObjectType):
                 id=get_node_id_from_global_id(kwargs["child_id"], "ChildNode")
             )
             return event.ticket_system_passwords.get(child=child).value
-        except (Child.DoesNotExist, TicketSystemPassword.DoesNotExist) as e:
+        except TicketSystemPassword.DoesNotExist:
+            return None
+        except Child.DoesNotExist as e:
             raise ObjectDoesNotExistError(e)
 
 

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -2548,13 +2548,16 @@ def test_event_ticket_system_password_own_child_no_password(guardian_api_client)
         variables=variables,
     )
 
-    assert_match_error_code(executed, OBJECT_DOES_NOT_EXIST_ERROR)
+    assert executed["data"]["event"]["ticketSystem"]["childPassword"] is None
     assert not child.ticket_system_passwords.filter(event=event).exists()
 
 
 def test_event_ticket_system_password_not_own_child(guardian_api_client):
     event = EventFactory(ticket_system=Event.TICKETMASTER, published_at=now())
     another_child = ChildWithGuardianFactory()
+    another_childs_password = TicketSystemPasswordFactory(  # noqa: F841
+        event=event, child=another_child, value="FATAL LEAK"
+    )
     some_free_password = TicketSystemPasswordFactory(event=event)  # noqa: F841
 
     variables = {
@@ -2562,30 +2565,12 @@ def test_event_ticket_system_password_not_own_child(guardian_api_client):
         "childId": get_global_id(another_child),
     }
 
-    # try to assign a password to someone else's child
     executed = guardian_api_client.execute(
         EVENT_TICKET_SYSTEM_PASSWORD_QUERY,
         variables=variables,
     )
 
     assert_match_error_code(executed, OBJECT_DOES_NOT_EXIST_ERROR)
-    assert not another_child.ticket_system_passwords.filter(event=event).exists()
-
-    another_childs_password = TicketSystemPasswordFactory(
-        event=event, child=another_child, value="FATAL LEAK"
-    )
-
-    # try to read an assigned password of someone else's child
-    executed = guardian_api_client.execute(
-        EVENT_TICKET_SYSTEM_PASSWORD_QUERY,
-        variables=variables,
-    )
-
-    assert_match_error_code(executed, OBJECT_DOES_NOT_EXIST_ERROR)
-    assert (
-        another_child.ticket_system_passwords.get(event=event)
-        == another_childs_password
-    )
 
 
 ASSIGN_TICKET_SYSTEM_PASSWORD_MUTATION = """


### PR DESCRIPTION
During the typical ticket system password redeem flow in the UI, we need to first figure out whether the child has a password to the event or not, so it makes more sense to return null instead of an error in that situation.