### PR TITLE
Process notifications sending outside the atomic transaction of saving of events

### DIFF
--- a/events/utils.py
+++ b/events/utils.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterable
 from datetime import datetime
 from typing import List, Optional
@@ -9,12 +10,16 @@ from parler.utils.context import switch_language
 
 from common.utils import get_global_id
 
+logger = logging.getLogger(__name__)
+
 
 def send_event_notifications_to_guardians(
     event, notification_type, children, attachments: Optional[List] = None, **kwargs
 ):
     if not isinstance(children, Iterable):
         children = [children]
+
+    context_for_address = {}
 
     for child in children:
         for guardian in child.guardians.all():
@@ -36,14 +41,31 @@ def send_event_notifications_to_guardians(
                     context["occurrence_enrol_url"] = get_occurrence_enrol_ui_url(
                         occurrence, child, guardian.language
                     )
+                context_for_address[guardian.email] = context
 
-                send_notification(
-                    guardian.email,
-                    notification_type,
-                    context=context,
-                    language=guardian.language,
-                    attachments=attachments,
-                )
+    emails = ",".join(context_for_address.keys())
+    logger.debug(
+        f"There are {len(emails)} total in the notification list. "
+        f"Notification will be sent to these addresses: {emails}"
+    )
+    # NOTE: Instead of sending the notification in the previous loop,
+    # lets first collect the mail contexts to a dictionary and
+    # send the mails after all the contexts have been handled properly.
+    # This way we can prevent flooding the recipients with the mails
+    # when some of the contexts cannot be handled because of any reason.
+    # For more details, see
+    # 1. https://helsinkisolutionoffice.atlassian.net/browse/KK-984,
+    # 2. https://helsinkisolutionoffice.atlassian.net/browse/PT-1414.
+    for address, context in context_for_address.items():
+        logger.debug(f"Sending event notification to {address}.")
+        guardian = context["guardian"]
+        send_notification(
+            email=address,
+            notification_type=notification_type,
+            context=context,
+            language=guardian.language,
+            attachments=attachments,
+        )
 
 
 def send_event_group_notifications_to_guardians(


### PR DESCRIPTION
KK-984.
The object instance save-process should be handled in a transaction,
so if any errors occurs, the whole process is rolled back.
The sending of notifications (emails and sms) cannot be in that same transaction,
because a sent message cannot be rolled back --
the receiver has already received the message.

The notifications context should be processed as much as possible
before the actual sending, so that any issues should have been already raised,
before any of the messages has been delivered yet.