### PR TITLE
Add Lippupiste as an external ticket system

### DIFF
--- a/events/factories.py
+++ b/events/factories.py
@@ -1,3 +1,5 @@
+import random
+
 import factory
 import pytz
 from django.utils import timezone
@@ -37,12 +39,25 @@ class EventFactory(factory.django.DjangoModelFactory):
         model = Event
 
 
-class TicketmasterEventFactory(EventFactory):
+def get_external_ticket_system():
+    "Return a random external ticket system from available choices"
+    return random.choice(list(zip(*Event.EXTERNAL_TICKET_SYSTEM_CHOICES))[0])
+
+
+class RandomExternalTicketSystemEventFactory(EventFactory):
     published_at = factory.LazyFunction(lambda: timezone.now())
-    ticket_system = Event.TICKETMASTER
+    ticket_system = factory.LazyFunction(get_external_ticket_system)
     ticket_system_url = factory.Faker("url")
     capacity_per_occurrence = None
     duration = None
+
+
+class TicketmasterEventFactory(RandomExternalTicketSystemEventFactory):
+    ticket_system = Event.TICKETMASTER
+
+
+class LippupisteEventFactory(RandomExternalTicketSystemEventFactory):
+    ticket_system = Event.LIPPUPISTE
 
 
 class OccurrenceFactory(factory.django.DjangoModelFactory):

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -107,6 +107,9 @@ query Events {
                 ... on TicketmasterOccurrenceTicketSystem {
                   url
                 }
+                ... on LippupisteOccurrenceTicketSystem {
+                  url
+                }
               }
             }
           }
@@ -161,6 +164,9 @@ query Event($id: ID!) {
           ticketSystem {
             type
             ... on TicketmasterOccurrenceTicketSystem {
+              url
+            }
+            ... on LippupisteOccurrenceTicketSystem {
               url
             }
           }
@@ -219,6 +225,9 @@ query Occurrences {
         ticketSystem {
           type
           ... on TicketmasterOccurrenceTicketSystem {
+            url
+          }
+          ... on LippupisteOccurrenceTicketSystem {
             url
           }
         }
@@ -289,6 +298,9 @@ query Occurrence($id: ID!) {
     ticketSystem {
       type
       ... on TicketmasterOccurrenceTicketSystem {
+        url
+      }
+      ... on LippupisteOccurrenceTicketSystem {
         url
       }
     }

--- a/kukkuu/schema.py
+++ b/kukkuu/schema.py
@@ -11,6 +11,8 @@ import venues.schema
 from events.schema import (
     InternalEventTicketSystem,
     InternalOccurrenceTicketSystem,
+    LippupisteEventTicketSystem,
+    LippupisteOccurrenceTicketSystem,
     TicketmasterEventTicketSystem,
     TicketmasterOccurrenceTicketSystem,
 )
@@ -46,8 +48,10 @@ schema = graphene.Schema(
     mutation=Mutation,
     types=[
         TicketmasterEventTicketSystem,
+        LippupisteEventTicketSystem,
         InternalEventTicketSystem,
         TicketmasterOccurrenceTicketSystem,
+        LippupisteOccurrenceTicketSystem,
         InternalOccurrenceTicketSystem,
     ],
 )


### PR DESCRIPTION
KK-987 KK-994.

The integration for the external ticket systems,
the Ticketmaster and the Lippupiste, should be similar.
Only thing that varies at this point , is the ticket system URL.

The old Ticketmaster model and schema classes are now renamed
and converted to some abstract classes. The old Ticketmaster class names
are now given to the new classes that inherits the abstracts.
New Lippupiste classes are copied from the new Ticketmaster ones.

The old implementation for Ticketmaster should be unchanged,
so all the existing unit tests should pass without any changes.
There are now some changes added there only to randomly test that also
the Lippupiste events are calculated in same manners.