### PR TITLE
KK-997 | feat: add hashes to reporting API to evaluate number of unique accounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,11 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt -r requirements-dev.txt codecov
+          pip install -r requirements.txt -r requirements-dev.txt
       - name: Run tests
         run: pytest -ra -vv --doctest-modules --cov=.
         env:
           DATABASE_URL: postgres://kukkuu:kukkuu@localhost:5432/kukkuu
-
-      - name: Coverage
-        run: codecov
 
   coding-style:
     name: Coding style

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 :baby: Culture Kids (kulttuurin kummilapset) API :violin:
 
 [![status](https://travis-ci.com/City-of-Helsinki/kukkuu.svg)](https://github.com/City-of-Helsinki/kukkuu)
-[![codecov](https://codecov.io/gh/City-of-Helsinki/kukkuu/branch/develop/graph/badge.svg)](https://codecov.io/gh/City-of-Helsinki/kukkuu)
 
 ## Environments
 

--- a/children/factories.py
+++ b/children/factories.py
@@ -30,3 +30,7 @@ class RelationshipFactory(factory.django.DjangoModelFactory):
 class ChildWithGuardianFactory(ChildFactory):
     relationship = factory.RelatedFactory(RelationshipFactory, "child")
     project = factory.LazyFunction(lambda: Project.objects.get(year=2020))
+
+
+class ChildWithTwoGuardiansFactory(ChildWithGuardianFactory):
+    relationship2 = factory.RelatedFactory(RelationshipFactory, "child")

--- a/reports/api.py
+++ b/reports/api.py
@@ -77,6 +77,15 @@ LANGUAGE_CHOICES = [
     ]
 )
 class ChildSerializer(serializers.ModelSerializer):
+    child_birthdate_postal_code_guardian_emails_hash = serializers.SerializerMethodField(  # noqa
+        help_text="Salted hash of child's birthdate, postal code and guardians' emails."
+    )
+    child_name_birthdate_postal_code_guardian_emails_hash = (
+        serializers.SerializerMethodField(
+            help_text="Salted hash of child's name (i.e. first name and last name), "
+            "birthdate, postal code and guardians' emails."
+        )
+    )
     registration_date = serializers.SerializerMethodField()
     birth_year = serializers.SerializerMethodField()
     contact_language = serializers.SerializerMethodField()
@@ -88,12 +97,29 @@ class ChildSerializer(serializers.ModelSerializer):
     class Meta:
         model = Child
         fields = [
+            "child_birthdate_postal_code_guardian_emails_hash",
+            "child_name_birthdate_postal_code_guardian_emails_hash",
             "registration_date",
             "birth_year",
             "postal_code",
             "contact_language",
             "languages_spoken_at_home",
         ]
+
+    def get_child_birthdate_postal_code_guardian_emails_hash(self, child: Child) -> str:
+        """
+        Salted hash of child's birthdate, postal code and guardians' emails.
+        """
+        return child.birthdate_postal_code_guardian_emails_hash
+
+    def get_child_name_birthdate_postal_code_guardian_emails_hash(
+        self, child: Child
+    ) -> str:
+        """
+        Salted hash of child's name (i.e. first name and last name), birthdate, postal
+        code and guardians' emails.
+        """
+        return child.name_birthdate_postal_code_guardian_emails_hash
 
     def get_registration_date(self, obj: Child) -> date:
         return localdate(obj.created_at)

--- a/reports/tests/snapshots/snap_test_api.py
+++ b/reports/tests/snapshots/snap_test_api.py
@@ -8,14 +8,9 @@ snapshots = Snapshot()
 
 snapshots["test_children_endpoint 1"] = [
     {
-        "birth_year": 2021,
-        "contact_language": "fin",
-        "languages_spoken_at_home": ["fin", "__OTHER__"],
-        "postal_code": "11111",
-        "registration_date": "2021-02-02",
-    },
-    {
         "birth_year": 2020,
+        "child_birthdate_postal_code_guardian_emails_hash": "b5b9eea93c3646a569ad517bab7ffc287fa331a3b07bfcda41f1936ff90f80c5",
+        "child_name_birthdate_postal_code_guardian_emails_hash": "1ad9ef9b725a22b13ecbee9dc0945b1a468240d7492923ec2d7eb4c67f5703ee",
         "contact_language": "eng",
         "languages_spoken_at_home": [],
         "postal_code": "33333",
@@ -23,9 +18,29 @@ snapshots["test_children_endpoint 1"] = [
     },
     {
         "birth_year": 2021,
+        "child_birthdate_postal_code_guardian_emails_hash": "72fa21cf7750f88d4085086b143a56ec6ba196c98693f1e4e7f39b76f9e2803e",
+        "child_name_birthdate_postal_code_guardian_emails_hash": "68ef0bbeef51ca5ff6282ec476c68fde6125383fe843ee00fe26a9536ccedfd0",
+        "contact_language": "fin",
+        "languages_spoken_at_home": ["fin", "__OTHER__"],
+        "postal_code": "11111",
+        "registration_date": "2021-02-02",
+    },
+    {
+        "birth_year": 2021,
+        "child_birthdate_postal_code_guardian_emails_hash": "db91f2de11ce26e8e49e179cd27e77805acc984af98aabab9d45987cc45c255c",
+        "child_name_birthdate_postal_code_guardian_emails_hash": "ff50591af6bd0de44d49c016d479c86b28c5180305548ca3a60be9d6621a2cac",
         "contact_language": "swe",
         "languages_spoken_at_home": ["__OTHER__"],
         "postal_code": "22222",
         "registration_date": "2021-03-03",
+    },
+    {
+        "birth_year": 2020,
+        "child_birthdate_postal_code_guardian_emails_hash": "0fcf4364217ea26d51ab38193066474515824eaaf3f387eca934375e36b16ee1",
+        "child_name_birthdate_postal_code_guardian_emails_hash": "87161feae33c32f46815b856d80ec4c564fb00ec680941245553982b2bd70f8c",
+        "contact_language": "eng",
+        "languages_spoken_at_home": [],
+        "postal_code": "33333",
+        "registration_date": "2021-04-06",
     },
 ]

--- a/reports/tests/test_api.py
+++ b/reports/tests/test_api.py
@@ -4,10 +4,15 @@ from datetime import date
 import freezegun
 import pytest
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from guardian.shortcuts import assign_perm, remove_perm
 from rest_framework.test import APIClient
 
-from children.factories import ChildFactory, ChildWithGuardianFactory
+from children.factories import (
+    ChildFactory,
+    ChildWithGuardianFactory,
+    ChildWithTwoGuardiansFactory,
+)
 from languages.models import Language
 from reports.drf_permissions import ACCESS_REPORT_API_PERM
 
@@ -56,29 +61,54 @@ def test_children_endpoint_no_permission(user_api_client):
 
 
 @pytest.mark.django_db
+@override_settings(
+    # Must be the same as in CI pipeline for the snapshot to be an exact match:
+    KUKKUU_HASHID_SALT="almosttopsecret123"
+)
 def test_children_endpoint(user_api_client, snapshot, django_assert_max_num_queries):
     with freezegun.freeze_time("2021-02-02T12:00:00Z"):
         ChildWithGuardianFactory(
+            first_name="John",
+            last_name="Doe",
             birthdate=date(2021, 1, 1),
             postal_code="11111",
             relationship__guardian__language="fi",
             relationship__guardian__languages_spoken_at_home=["fin", None],
+            relationship__guardian__email="advocate@example.org",
         )
 
     with freezegun.freeze_time("2021-03-03T01:00:00Z"):
         ChildWithGuardianFactory(
+            first_name="Isabella",
+            last_name="Garcia",
             birthdate=date(2021, 2, 2),
             postal_code="22222",
             relationship__guardian__language="sv",
             relationship__guardian__languages_spoken_at_home=[None],
+            relationship__guardian__email="parent@example.org",
         )
 
     # This guy's registration date should be 2021-04-05 in Helsinki time
     with freezegun.freeze_time("2021-04-04T23:00:00Z"):
         ChildWithGuardianFactory(
+            first_name="Jane",
+            last_name="Doe",
             birthdate=date(2020, 3, 3),
             postal_code="33333",
             relationship__guardian__language="en",
+            relationship__guardian__email="",
+        )
+
+    with freezegun.freeze_time("2021-04-05T21:05:00Z"):
+        ChildWithTwoGuardiansFactory(
+            first_name="First name",
+            last_name="Last name",
+            birthdate=date(2020, 3, 3),
+            postal_code="33333",
+            relationship__guardian__language="en",
+            relationship__guardian__email="guardian@example.org",
+            relationship2__guardian__language="sv",
+            relationship2__guardian__email="advocate@example.org",
         )
 
     ChildFactory()  # This is an orphan child so she should not be in the results


### PR DESCRIPTION
## Description

### fix: remove codecov (removed from PyPi), on Platta Sonarcloud is used 

https://about.codecov.io/blog/message-regarding-the-pypi-package/
> On April 12, 2023, Codecov removed the codecov package from PyPI.
> Our intent was to remove a deprecated, rarely-used package from active
> support.

refs TC-67 (codecov removed from PyPi)
refs KK-997
 
### feat: add hashes to reporting API to evaluate number of unique accounts 

add hashes to reporting API:
 - child_birthdate_postal_code_guardian_emails_hash
   - Salted hash of child's birthdate, postal code and guardians'
     emails.
 - child_name_birthdate_postal_code_guardian_emails_hash
   - Salted hash of child's name (i.e. first name and last name),
     birthdate, postal code and guardians' emails.
 - add to tests:
   - test_child_birthdate_postal_code_guardian_emails_hash
   - test_child_name_birthdate_postal_code_guardian_emails_hash
   - test_child_hashes_email_change
   - more coverage to test_children_endpoint

refs KK-997 (unique account number evaluating)

## Closes

[KK-997](https://helsinkisolutionoffice.atlassian.net/browse/KK-997)

## Testing

Tested locally:
 - `docker-compose up --build`
 - `docker exec -it kukkuu-backend bash`
 - `pytest . -vv`
   - All tests passed!

[KK-997]: https://helsinkisolutionoffice.atlassian.net/browse/KK-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ