### PR TITLE
Child update mutation input should not have birthdate field

### DIFF
--- a/children/schema.py
+++ b/children/schema.py
@@ -439,7 +439,6 @@ class UpdateChildMutation(graphene.relay.ClientIDMutation):
     class Input:
         id = graphene.ID(required=True)
         name = graphene.String()
-        birthyear = graphene.Int()
         postal_code = graphene.String()
         relationship = RelationshipInput()
         languages_spoken_at_home = graphene.List(graphene.NonNull(graphene.ID))

--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -602,7 +602,7 @@ snapshots["test_upcoming_events_and_event_groups 1"] = {
 snapshots["test_update_child_mutation 1"] = {
     "data": {
         "updateChild": {
-            "child": {"birthyear": 2020, "name": "Matti", "postalCode": "00840"}
+            "child": {"birthyear": 2021, "name": "Matti", "postalCode": "00840"}
         }
     }
 }

--- a/reports/tests/snapshots/snap_test_api.py
+++ b/reports/tests/snapshots/snap_test_api.py
@@ -38,7 +38,7 @@ snapshots["test_children_endpoint 1"] = [
         "birthyear": 2020,
         "child_birthyear_postal_code_guardian_emails_hash": "f1694b9c7d7a45c8606d9506f171025079940fcc97d5e125e1cc73495461f378",
         "child_name_birthyear_postal_code_guardian_emails_hash": "92d10305295a1210620ae3158c5aeecc24d9018be279042e8226d120cbfdb978",
-        "contact_language": "swe",
+        "contact_language": "eng",
         "languages_spoken_at_home": [],
         "postal_code": "44444",
         "registration_date": "2021-04-06",


### PR DESCRIPTION
KK-428

The updating of the child's birthdate field should not be possible anymore. This pull request requires changes from the client too, because it is currently including the birthdate-field in the mutation input.

NOTE: There is an [alternative PR](https://github.com/City-of-Helsinki/kukkuu/pull/333) for this that does not remove but deprecates the field from the child update mutation input.

NOTE: https://github.com/City-of-Helsinki/kukkuu/pull/336 and https://github.com/City-of-Helsinki/kukkuu/pull/336 will force some API changes anyway, so therefore this PR is recommended over the https://github.com/City-of-Helsinki/kukkuu/pull/333.