### PR TITLE
docs: add Django model hierarchy used in GDPR API data export to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,26 @@ To use the SMS notification functionality, you have to acquire the API_KEY from 
 - Run `python manage.py runserver localhost:8081`
 - The project is now running at [localhost:8081](http://localhost:8081)
 
+## GDPR API data export
+
+Django model hierarchy used in GDPR API data export (This graph is based on the Django models' `serialize_fields` values):
+```mermaid
+erDiagram
+    User ||--o{ Project : "administers"
+    User ||--|| Guardian : "is"
+      Guardian ||--o{ Child : "has"
+        Child ||--|| Enrolment : "has"
+          Enrolment ||--o{ Occurrence : "has"
+            Occurrence ||--|| Event : "is for"
+              Event ||--o{ EventGroup : "is part of"
+                EventGroup ||--|| Project : "is for"
+              Event ||--|| Project : "is for"
+            Occurrence ||--|| Venue : "is at"
+        Child ||--o{ TicketSystemPassword : "has"
+          TicketSystemPassword ||--|| Event : "is for"
+        Child ||--o{ FreeSpotNotificationSubscription : "has"
+```
+
 ## GraphQL API Documentation
 
 To view the GraphQL API documentation, in DEBUG mode visit: http://localhost:8081/graphql and checkout the `Documentation Explorer` section


### PR DESCRIPTION
## Description

### docs: add Django model hierarchy used in GDPR API data export to README

github & gitlab should both support mermaid syntax already, and e.g. JetBrains PyCharm supports mermaid syntax using a plugin.

refs KK-1073

## Screenshots

![image](https://github.com/City-of-Helsinki/kukkuu/assets/77663720/744166c0-58aa-438b-b71d-15501bbd9615)
![image](https://github.com/City-of-Helsinki/kukkuu/assets/77663720/075d17a6-0d17-4159-9d3a-46d582af0a16)
