### PR TITLE
fix: projects model objects manager

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -299,6 +299,7 @@ class TicketSystemChildPasswordAdmin(admin.ModelAdmin):
         "child",
         "assigned_at",
     )
+    autocomplete_fields = ("child",)
     list_display = (
         "value",
         "event",

--- a/projects/models.py
+++ b/projects/models.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from helsinki_gdpr.models import SerializableMixin
 from parler.models import TranslatableModel, TranslatedFields
 
+from common.models import TranslatableQuerySet
 from common.utils import get_translations_dict
 
 
@@ -31,7 +32,9 @@ class Project(TranslatableModel, SerializableMixin):
         {"name": "name_with_translations"},
     ]
 
-    objects = SerializableMixin.SerializableManager()
+    objects = SerializableMixin.SerializableManager().from_queryset(
+        TranslatableQuerySet
+    )()
 
     class Meta:
         verbose_name = _("project")


### PR DESCRIPTION
Fix the projects objects manager -- It broke when the serializable mixin was taken in use.

Also make the child field of the TicketSystemPassword admin to autocompletable / searchable.