### PR TITLE
fix: upgrade the django-helusers to fix issues with GDPR API auth

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ Django
 django-cors-headers
 django-environ
 # when helusers is upgraded, check if the expired token thingy in kukkuu.graphene.JWTMiddleware could be improved (and does it even still work)
-django-helusers==0.7.0
+django-helusers==0.11.0
 django-ilmoitin
 django-parler
 django-cleanup

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ django-filter==21.1
     # via -r requirements.in
 django-guardian==2.4.0
     # via -r requirements.in
-django-helusers==0.7.0
+django-helusers==0.11.0
     # via
     #   -r requirements.in
     #   helsinki-profile-gdpr-api


### PR DESCRIPTION
KK-1097 KK-1117.

When the GDPR API requests data from the Kukkuu API,
it must use an authorization token (which in this point is issued by Tunnistamo).
The issued JWT auth token has the amr-field in a string format, 
when it should be a list. Upgrading the helusers-package fixes the auth issues.
