### PR TITLE
feat: send event and event group publish notification in a thread

### DIFF
--- a/common/decorators.py
+++ b/common/decorators.py
@@ -1,0 +1,37 @@
+import logging
+from functools import wraps
+from threading import Thread
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def execute_in_background(
+    thread_name: Optional[str] = None, daemonic: Optional[bool] = None
+):
+    """A decorator to execute a function in a new thread in background.
+
+    Args:
+        daemonic (Optional[bool], optional): Set a new thread as daemonic.
+            If not None, daemon explicitly sets whether the thread is daemonic.
+            If None, the daemonic property is inherited from the current thread.
+            Defaults to None.
+    """
+
+    def decorator(target_function):
+        @wraps(target_function)
+        def start_thread(*args, **kwargs):
+            logger.debug("Creating a new thread to execute a function in background...")
+            thread = Thread(
+                name=thread_name,
+                target=target_function,
+                args=args,
+                kwargs=kwargs,
+                daemon=daemonic,
+            )
+            logger.info(f"Starting a thread [{thread}].")
+            thread.start()
+
+        return start_thread
+
+    return decorator

--- a/events/utils.py
+++ b/events/utils.py
@@ -1,9 +1,10 @@
 import logging
 from collections.abc import Iterable
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING, Union
 
 from django.conf import settings
+from django.db.models import QuerySet
 from django.utils import timezone
 from django_ilmoitin.utils import send_notification
 from parler.utils.context import switch_language
@@ -11,11 +12,20 @@ from parler.utils.context import switch_language
 from common.utils import get_global_id
 from users.utils import get_marketing_unsubscribe_ui_url
 
+if TYPE_CHECKING:
+    from children.models import Child
+    from events.consts import NotificationType
+    from events.models import Event, EventGroup
+
 logger = logging.getLogger(__name__)
 
 
 def send_event_notifications_to_guardians(
-    event, notification_type, children, attachments: Optional[List] = None, **kwargs
+    event: "Event",
+    notification_type: "NotificationType",
+    children: Union[QuerySet, List["Child"]],
+    attachments: Optional[List] = None,
+    **kwargs,
 ):
     if not isinstance(children, Iterable):
         children = [children]
@@ -74,7 +84,10 @@ def send_event_notifications_to_guardians(
 
 
 def send_event_group_notifications_to_guardians(
-    event_group, notification_type, children, **kwargs
+    event_group: "EventGroup",
+    notification_type: "NotificationType",
+    children: Union[QuerySet, List["Child"]],
+    **kwargs,
 ):
     if not isinstance(children, Iterable):
         children = [children]


### PR DESCRIPTION
KK-1035.

Added a new common decorator that can be used to execute tasks in background
in a new thread.

If there are thousands of email recipients, the process of creating the mails
will take tens of seconds. While the process is handled in the same
request handler as the event state change, the response takes long to be sent,
which leads to a connection timeout, that will write an error message
to the admin UI. To prevent that, the state change could be done as an atomic
operation as it has always been done, but the emails could be sent in an another
thread. The response is then sent when the atomic process finishes and the email
sending is not awaited.

More about the threading for email sending:
- https://ozcanyarimdunya.github.io/dj_threading/
- https://medium.com/@akshatgadodia/simplifying-email-sending-in-django-a-step-by-step-guide-7dc90079738b
fix: db connection was not working properly in pytests

Some of the pytests needed some threading handling: the database connection was not shared 
with the newly spawned threads, so e.g. the sent mails were not shown in the mail box because
the querysets were empty. Using `@pytest.mark.django_db(transaction=True)` helped in that.

----

NOTE: The threading might be a problem with our UWSGI!

"Django threading": https://ozcanyarimdunya.github.io/dj_threading/ 

"Sending Emails in the Background with Multithreading": https://medium.com/@akshatgadodia/simplifying-email-sending-in-django-a-step-by-step-guide-7dc90079738b. 

"Django-allauth using threads": https://github.com/pennersr/django-allauth/issues/1451. 

"Threads should be used", "Celery is definitely an Overkill for just sending emails..." https://stackoverflow.com/questions/4447081/how-to-send-asynchronous-email-using-django. 

"Using threads for offloading request is not so good idea...": https://stackoverflow.com/questions/17507968/django-threading-and-tests?rq=4 

"Threads are bad solution...": https://stackoverflow.com/questions/13567160/django-best-way-to-send-email-in-background. 

"Process or Thread problem deploying Django app with uWSGI": https://forum.djangoproject.com/t/process-or-thread-problem-deploying-django-app-with-uwsgi/22189 

UWSGI configuration for threading: https://stackoverflow.com/questions/58389626/multiprocessing-process-is-blocking-the-return-statement-when-running-with-uwsgi.