### PR TITLE
refactor: move named GraphQL query/mutation variables to own files

### DIFF
--- a/children/tests/mutations.py
+++ b/children/tests/mutations.py
@@ -1,0 +1,84 @@
+SUBMIT_CHILDREN_AND_GUARDIAN_MUTATION = """
+mutation SubmitChildrenAndGuardian($input: SubmitChildrenAndGuardianMutationInput!) {
+  submitChildrenAndGuardian(input: $input) {
+    children {
+      name
+      birthyear
+      postalCode
+      relationships {
+        edges {
+          node {
+            type
+            guardian {
+              firstName
+              lastName
+              phoneNumber
+              email
+            }
+          }
+        }
+      }
+    }
+    guardian {
+      firstName
+      lastName
+      phoneNumber
+      email
+      languagesSpokenAtHome {
+        edges {
+          node {
+            alpha3Code
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+ADD_CHILD_MUTATION = """
+mutation AddChild($input: AddChildMutationInput!) {
+  addChild(input: $input) {
+    child {
+      name
+      birthyear
+      postalCode
+    }
+  }
+}
+"""
+
+
+UPDATE_CHILD_MUTATION = """
+mutation UpdateChild($input: UpdateChildMutationInput!) {
+  updateChild(input: $input) {
+    child {
+      name
+      birthyear
+      postalCode
+    }
+  }
+}
+"""
+
+DELETE_CHILD_MUTATION = """
+mutation DeleteChild($input: DeleteChildMutationInput!) {
+  deleteChild(input: $input) {__typename}
+}
+"""
+
+UPDATE_CHILD_NOTES_MUTATION_TEMPLATE = """
+mutation UpdateChildNotes($input: UpdateChildNotesMutationInput!) {
+  updateChildNotes(input: $input) {
+    childNotes {
+      childId
+      notes
+      %(extra_field_name)s
+    }
+  }
+}
+"""
+
+UPDATE_CHILD_NOTES_MUTATION = UPDATE_CHILD_NOTES_MUTATION_TEMPLATE % {
+    "extra_field_name": ""
+}

--- a/children/tests/queries.py
+++ b/children/tests/queries.py
@@ -1,0 +1,235 @@
+CHILDREN_QUERY = """
+query Children {
+  children {
+    edges {
+      node {
+        name
+        birthyear
+        postalCode
+        relationships {
+          edges {
+            node {
+              type
+              guardian {
+                firstName
+                lastName
+                phoneNumber
+                email
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+CHILDREN_FILTER_QUERY = """
+query Children($projectId: ID!) {
+  children(projectId: $projectId) {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}
+"""
+
+
+CHILD_QUERY = """
+query Child($id: ID!) {
+  child(id: $id) {
+    name
+    birthyear
+    postalCode
+    relationships {
+      edges {
+        node {
+          type
+          guardian {
+            firstName
+            lastName
+            phoneNumber
+            email
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+CHILD_EVENTS_QUERY = """
+query Child($id: ID!) {
+  child(id: $id) {
+    availableEvents{
+      edges{
+        node{
+          createdAt
+          occurrences{
+            edges{
+              node{
+                remainingCapacity
+              }
+            }
+          }
+        }
+      }
+    }
+    pastEvents{
+      edges{
+        node{
+          createdAt
+          name
+          occurrences{
+            edges{
+              node{
+                remainingCapacity
+              }
+            }
+          }
+        }
+      }
+    }
+    occurrences {
+      edges {
+        node {
+          time
+        }
+      }
+    }
+  }
+}
+"""
+
+CHILD_NOTES_QUERY_TEMPLATE = """
+query ChildNotes($id: ID!) {
+  childNotes(id: $id) {
+    childId
+    notes
+    %(extra_field_name)s
+  }
+}
+"""
+
+CHILD_NOTES_QUERY = CHILD_NOTES_QUERY_TEMPLATE % {"extra_field_name": ""}
+
+CHILD_NOTES_QUERY_WITHOUT_ID_PARAMETER = """
+query ChildNotes {
+  childNotes {
+    childId
+    notes
+  }
+}
+"""
+
+CHILD_ENROLMENT_COUNT_QUERY = """
+query Child($id: ID!, $year: Int) {
+  child(id: $id) {
+    enrolmentCount(year: $year)
+    pastEnrolmentCount
+  }
+}
+"""
+
+
+CHILD_PAST_EVENTS_QUERY = """
+query Child($id: ID!) {
+  child(id: $id) {
+    pastEvents {
+      edges {
+        node {
+          name
+        }
+      }
+    }
+  }
+}
+"""
+
+CHILDREN_PAGINATION_QUERY = """
+query Children($projectId: ID!, $limit: Int, $offset: Int, $after: String, $first: Int) {
+  children(projectId: $projectId, limit: $limit, offset: $offset, after: $after, first: $first) {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}
+"""  # noqa: E501
+
+CHILD_AVAILABLE_EVENTS_AND_EVENT_GROUPS_QUERY = """
+query Child($id: ID!) {
+  child(id: $id) {
+    availableEventsAndEventGroups{
+      edges {
+        node {
+          ... on EventNode {
+            name
+            __typename
+          }
+          ... on EventGroupNode {
+            name
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+CHILD_UPCOMING_EVENTS_AND_EVENT_GROUPS_QUERY = """
+query Child($id: ID!) {
+  child(id: $id) {
+    upcomingEventsAndEventGroups{
+      edges {
+        node {
+          ... on EventNode {
+            name
+            canChildEnroll(childId: $id)
+            __typename
+          }
+          ... on EventGroupNode {
+            name
+            canChildEnroll(childId: $id)
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+CHILD_ACTIVE_INTERNAL_AND_TICKETMASTER_ENROLMENTS_QUERY = """
+query Child($id: ID!) {
+  child(id: $id) {
+    activeInternalAndTicketSystemEnrolments{
+      edges {
+        node {
+          ... on EnrolmentNode {
+            occurrence {
+              event {
+                name
+              }
+            }
+            __typename
+          }
+          ... on TicketmasterEnrolmentNode {
+            createdAt
+            event {
+              name
+            }
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+"""

--- a/children/tests/test_notifications.py
+++ b/children/tests/test_notifications.py
@@ -3,10 +3,8 @@ from copy import deepcopy
 import pytest
 from django.core import mail
 
-from children.tests.test_api import (
-    SUBMIT_CHILDREN_AND_GUARDIAN_MUTATION,
-    SUBMIT_CHILDREN_AND_GUARDIAN_VARIABLES,
-)
+from children.tests.mutations import SUBMIT_CHILDREN_AND_GUARDIAN_MUTATION
+from children.tests.test_api import SUBMIT_CHILDREN_AND_GUARDIAN_VARIABLES
 from common.tests.utils import (
     assert_mails_match_snapshot,
     create_notification_template_in_language,

--- a/events/tests/mutations.py
+++ b/events/tests/mutations.py
@@ -1,0 +1,307 @@
+ADD_EVENT_MUTATION = """
+mutation AddEvent($input: AddEventMutationInput!) {
+  addEvent(input: $input) {
+    event {
+      translations{
+        languageCode
+        name
+        description
+        imageAltText
+        shortDescription
+      }
+      project{
+        year
+      }
+      duration
+      image
+      imageAltText
+      participantsPerInvite
+      capacityPerOccurrence
+      publishedAt
+      readyForEventGroupPublishing
+      ticketSystem {
+        type
+      }
+    }
+  }
+}
+"""
+
+ADD_TICKETMASTER_EVENT_MUTATION = """
+mutation AddTicketmasterEvent($input: AddEventMutationInput!) {
+  addEvent(input: $input) {
+    event {
+      ticketSystem {
+        type
+      }
+    }
+  }
+}
+"""
+
+UPDATE_EVENT_MUTATION = """
+mutation UpdateEvent($input: UpdateEventMutationInput!) {
+  updateEvent(input: $input) {
+    event {
+      translations{
+        name
+        shortDescription
+        description
+        imageAltText
+        languageCode
+      }
+      image
+      imageAltText
+      participantsPerInvite
+      capacityPerOccurrence
+      duration
+      ticketSystem {
+        type
+      }
+      occurrences{
+        edges{
+          node{
+            time
+          }
+        }
+      }
+      readyForEventGroupPublishing
+    }
+  }
+}
+"""
+
+UPDATE_TICKETMASTER_EVENT_MUTATION = """
+mutation UpdateTicketmasterEvent($input: UpdateEventMutationInput!) {
+  updateEvent(input: $input) {
+    event {
+      ticketSystem {
+        type
+      }
+    }
+  }
+}
+"""
+
+PUBLISH_EVENT_MUTATION = """
+mutation PublishEvent($input: PublishEventMutationInput!) {
+  publishEvent(input: $input) {
+    event {
+      publishedAt
+    }
+  }
+}
+"""
+
+DELETE_EVENT_MUTATION = """
+mutation DeleteEvent($input: DeleteEventMutationInput!) {
+  deleteEvent(input: $input) {
+    __typename
+  }
+}
+"""
+
+ADD_OCCURRENCE_MUTATION = """
+mutation AddOccurrence($input: AddOccurrenceMutationInput!) {
+  addOccurrence(input: $input) {
+    occurrence{
+      event{
+        createdAt
+      }
+      venue {
+        createdAt
+      }
+      time
+      occurrenceLanguage
+      capacity
+      capacityOverride
+      ticketSystem {
+        type
+        ... on TicketmasterOccurrenceTicketSystem {
+          url
+        }
+      }
+    }
+  }
+}
+
+"""
+
+UPDATE_OCCURRENCE_MUTATION = """
+mutation UpdateOccurrence($input: UpdateOccurrenceMutationInput!) {
+  updateOccurrence(input: $input) {
+    occurrence{
+      event{
+        createdAt
+      }
+      venue {
+        createdAt
+      }
+      time
+      occurrenceLanguage
+      enrolmentCount
+      remainingCapacity
+      capacity
+      capacityOverride
+      ticketSystem {
+        type
+        ... on TicketmasterOccurrenceTicketSystem {
+          url
+        }
+      }
+    }
+  }
+}
+
+"""
+
+DELETE_OCCURRENCE_MUTATION = """
+mutation DeleteOccurrence($input: DeleteOccurrenceMutationInput!) {
+  deleteOccurrence(input: $input) {
+    __typename
+  }
+}
+
+"""
+
+ENROL_OCCURRENCE_MUTATION = """
+mutation EnrolOccurrence($input: EnrolOccurrenceMutationInput!) {
+  enrolOccurrence(input: $input) {
+    enrolment{
+      child{
+        name
+      }
+      occurrence {
+        time
+      }
+      createdAt
+    }
+  }
+}
+
+"""
+
+
+UNENROL_OCCURRENCE_MUTATION = """
+mutation UnenrolOccurrence($input: UnenrolOccurrenceMutationInput!) {
+  unenrolOccurrence(input: $input) {
+    occurrence{
+        time
+    }
+    child{
+        name
+    }
+  }
+}
+
+"""
+
+SET_ENROLMENT_ATTENDANCE_MUTATION = """
+mutation SetEnrolmentAttendance($input: SetEnrolmentAttendanceMutationInput!) {
+  setEnrolmentAttendance(input: $input) {
+    enrolment {
+      attended
+    }
+  }
+}
+
+"""
+
+ADD_EVENT_GROUP_MUTATION = """
+mutation AddEventGroup($input: AddEventGroupMutationInput!) {
+  addEventGroup(input: $input) {
+    eventGroup {
+      translations{
+        languageCode
+        name
+        description
+        imageAltText
+        shortDescription
+      }
+      project{
+        year
+      }
+      image
+      imageAltText
+      publishedAt
+    }
+  }
+}
+"""
+
+UPDATE_EVENT_GROUP_MUTATION = """
+mutation UpdateEventGroup($input: UpdateEventGroupMutationInput!) {
+  updateEventGroup(input: $input) {
+    eventGroup {
+      translations{
+        name
+        shortDescription
+        description
+        imageAltText
+        languageCode
+      }
+      image
+    }
+  }
+}
+"""
+
+DELETE_EVENT_GROUP_MUTATION = """
+mutation DeleteEventGroup($input: DeleteEventGroupMutationInput!) {
+  deleteEventGroup(input: $input) {
+    __typename
+  }
+}
+"""
+
+
+PUBLISH_EVENT_GROUP_MUTATION = """
+mutation PublishEventGroup($input: PublishEventGroupMutationInput!) {
+  publishEventGroup(input: $input) {
+    eventGroup {
+      publishedAt
+      events {
+        edges {
+          node {
+            publishedAt
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+IMPORT_TICKET_SYSTEM_PASSWORDS_MUTATION = """
+mutation ImportTicketSystemPasswordsMutation(
+    $input: ImportTicketSystemPasswordsMutationInput!
+) {
+  importTicketSystemPasswords(input: $input) {
+    event {
+      name
+    }
+    passwords
+    errors {
+        field
+        message
+        value
+    }
+  }
+}
+"""
+
+
+ASSIGN_TICKET_SYSTEM_PASSWORD_MUTATION = """
+mutation AssignTicketSystemPassword($input: AssignTicketSystemPasswordMutationInput!) {
+  assignTicketSystemPassword(input: $input) {
+    event {
+      name
+    }
+    child {
+      name
+    }
+    password
+  }
+}
+"""

--- a/events/tests/queries.py
+++ b/events/tests/queries.py
@@ -1,0 +1,404 @@
+EVENTS_QUERY = """
+query Events {
+  events {
+    edges {
+      node {
+        translations{
+          name
+          description
+          shortDescription
+          imageAltText
+          languageCode
+        }
+        project{
+          year
+        }
+        name
+        description
+        shortDescription
+        duration
+        image
+        imageAltText
+        participantsPerInvite
+        capacityPerOccurrence
+        publishedAt
+        createdAt
+        updatedAt
+        ticketSystem {
+          type
+        }
+        occurrences {
+          edges {
+            node {
+              remainingCapacity
+              enrolmentCount
+              time
+              venue {
+                translations{
+                  name
+                  description
+                  languageCode
+                }
+              }
+              ticketSystem {
+                type
+                ... on TicketmasterOccurrenceTicketSystem {
+                  url
+                }
+                ... on LippupisteOccurrenceTicketSystem {
+                  url
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+"""
+
+EVENT_QUERY = """
+query Event($id: ID!) {
+  event(id: $id) {
+    translations{
+      name
+      shortDescription
+      description
+      imageAltText
+      languageCode
+    }
+    project{
+      year
+    }
+    name
+    description
+    shortDescription
+    image
+    imageAltText
+    participantsPerInvite
+    capacityPerOccurrence
+    publishedAt
+    createdAt
+    updatedAt
+    duration
+    ticketSystem {
+      type
+    }
+    occurrences{
+      edges{
+        node{
+          time
+          remainingCapacity
+          enrolmentCount
+          venue{
+            translations{
+              name
+              description
+              languageCode
+            }
+          }
+          ticketSystem {
+            type
+            ... on TicketmasterOccurrenceTicketSystem {
+              url
+            }
+            ... on LippupisteOccurrenceTicketSystem {
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+EVENTS_FILTER_QUERY = """
+query Events($projectId: ID, $upcoming: Boolean) {
+  events(projectId: $projectId, upcoming: $upcoming) {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}
+"""
+
+OCCURRENCES_QUERY = """
+query Occurrences {
+  occurrences {
+    edges {
+      node {
+        time
+        remainingCapacity
+        enrolmentCount
+        event {
+          translations {
+            name
+            shortDescription
+            description
+            languageCode
+          }
+          image
+          participantsPerInvite
+          capacityPerOccurrence
+          publishedAt
+          duration
+        }
+        venue{
+          translations{
+            name
+            description
+            address
+            accessibilityInfo
+            arrivalInstructions
+            additionalInfo
+            wwwUrl
+            languageCode
+          }
+        }
+        ticketSystem {
+          type
+          ... on TicketmasterOccurrenceTicketSystem {
+            url
+          }
+          ... on LippupisteOccurrenceTicketSystem {
+            url
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+OCCURRENCES_FILTER_QUERY = """
+query Occurrences($date: Date, $time: Time, $upcoming: Boolean, $venueId: String,
+                  $eventId: String, $occurrenceLanguage: String, $projectId: String,
+                  $upcomingWithLeeway: Boolean, $upcomingWithOngoing: Boolean) {
+  occurrences(date: $date, time: $time, upcoming: $upcoming, venueId: $venueId,
+              eventId: $eventId, occurrenceLanguage: $occurrenceLanguage,
+              projectId: $projectId, upcomingWithLeeway: $upcomingWithLeeway,
+              upcomingWithOngoing: $upcomingWithOngoing) {
+    edges {
+      node {
+        time
+      }
+    }
+  }
+}
+"""
+
+OCCURRENCE_QUERY = """
+query Occurrence($id: ID!) {
+  occurrence(id: $id){
+    enrolments{
+        edges{
+          node{
+            child{
+              name
+            }
+          }
+        }
+    }
+    time
+    remainingCapacity
+    enrolmentCount
+    occurrenceLanguage
+    event {
+      translations {
+        name
+        shortDescription
+        description
+        languageCode
+      }
+      image
+      participantsPerInvite
+      capacityPerOccurrence
+      publishedAt
+      duration
+    }
+    venue{
+      translations{
+        name
+        description
+        address
+        accessibilityInfo
+        arrivalInstructions
+        additionalInfo
+        wwwUrl
+        languageCode
+      }
+    }
+    ticketSystem {
+      type
+      ... on TicketmasterOccurrenceTicketSystem {
+        url
+      }
+      ... on LippupisteOccurrenceTicketSystem {
+        url
+      }
+    }
+  }
+}
+"""
+
+CAN_CHILD_ENROLL_EVENT_QUERY = """
+query Event($id: ID!, $childId: ID!) {
+  event(id: $id) {
+    name
+    canChildEnroll(childId: $childId)
+  }
+}
+"""
+
+OCCURRENCES_COUNTS_QUERY_TEMPLATE = """
+query Occurrences {
+  occurrences {
+    edges {
+      node {
+        enrolmentCount
+        %(occurrence_fields)s
+      }
+    }
+  }
+}
+"""
+
+EVENT_GROUP_QUERY = """
+query EventGroup($id: ID!) {
+  eventGroup(id: $id) {
+    translations{
+      name
+      shortDescription
+      description
+      imageAltText
+      languageCode
+    }
+    project {
+      year
+    }
+    name
+    description
+    shortDescription
+    image
+    imageAltText
+    publishedAt
+    createdAt
+    updatedAt
+    events {
+      edges {
+        node {
+          __typename
+          name
+        }
+      }
+    }
+  }
+}
+"""
+
+EVENTS_AND_EVENT_GROUPS_SIMPLE_QUERY = """
+query EventsAndEventGroups($projectId: ID, $upcoming: Boolean) {
+  eventsAndEventGroups(projectId: $projectId, upcoming: $upcoming) {
+    edges {
+      node {
+        ... on EventNode {
+          __typename
+          name
+        }
+        ... on EventGroupNode {
+          __typename
+          name
+        }
+      }
+    }
+  }
+}
+"""
+
+EVENT_GROUP_EVENTS_FILTER_QUERY = """
+query EventGroup($id: ID!, $availableForChild: String) {
+  eventGroup(id: $id) {
+    events(availableForChild: $availableForChild) {
+      edges {
+        node {
+          name
+        }
+      }
+    }
+  }
+}
+"""
+
+
+OCCURRENCE_TICKET_SYSTEM_QUERY = """
+query Occurrence($id: ID!) {
+  occurrence(id: $id) {
+    ticketSystem {
+      type
+      ... on TicketmasterOccurrenceTicketSystem {
+        url
+      }
+    }
+  }
+}
+"""
+
+
+EVENT_TICKET_SYSTEM_PASSWORD_QUERY = """
+query TicketSystemChildPassword($eventId: ID!, $childId: ID!) {
+  event(id: $eventId) {
+    ticketSystem {
+      type
+      ... on TicketmasterEventTicketSystem {
+        childPassword(childId: $childId)
+      }
+    }
+  }
+}
+"""
+
+
+EVENT_TICKET_SYSTEM_PASSWORD_COUNTS_QUERY = """
+query TicketSystemPasswordCounts($eventId: ID!) {
+  event(id: $eventId) {
+    ticketSystem {
+      ... on TicketmasterEventTicketSystem {
+        freePasswordCount
+        usedPasswordCount
+      }
+    }
+  }
+}
+"""
+
+
+VERIFY_TICKET_QUERY = """
+  query VerifyTicket($referenceId: String!){
+    verifyTicket(referenceId:$referenceId){
+      occurrenceTime
+      eventName
+      venueName
+      validity
+    }
+  }
+"""
+
+
+GET_ENROLMENT_REFERENCE_ID_QUERY = """
+  query getChildEnrolments($id: ID!) {
+    child(id: $id){
+      enrolments {
+        edges {
+          node {
+            referenceId
+          }
+        }
+      }
+    }
+  }
+"""

--- a/events/tests/test_notifications.py
+++ b/events/tests/test_notifications.py
@@ -25,11 +25,8 @@ from events.factories import (
 )
 from events.models import Enrolment, Occurrence
 from events.notifications import NotificationType
-from events.tests.test_api import (
-    PUBLISH_EVENT_MUTATION,
-    PUBLISH_EVENT_VARIABLES,
-    UNENROL_OCCURRENCE_MUTATION,
-)
+from events.tests.mutations import PUBLISH_EVENT_MUTATION, UNENROL_OCCURRENCE_MUTATION
+from events.tests.test_api import PUBLISH_EVENT_VARIABLES
 from projects.factories import ProjectFactory
 from users.factories import GuardianFactory
 

--- a/gdpr/tests/snapshots/snap_test_gdpr_api.py
+++ b/gdpr/tests/snapshots/snap_test_gdpr_api.py
@@ -681,6 +681,10 @@ Daniellechester, KS 04855""",
                                     "children": [],
                                     "key": "FREE_SPOT_NOTIFICATION_SUBSCRIPTIONS",
                                 },
+                                {
+                                    "key": "NOTES",
+                                    "value": "GDPR sensitive test notes for child",
+                                },
                             ],
                             "key": "CHILD",
                         }

--- a/gdpr/tests/snapshots/snap_test_gdpr_api.py
+++ b/gdpr/tests/snapshots/snap_test_gdpr_api.py
@@ -681,10 +681,6 @@ Daniellechester, KS 04855""",
                                     "children": [],
                                     "key": "FREE_SPOT_NOTIFICATION_SUBSCRIPTIONS",
                                 },
-                                {
-                                    "key": "NOTES",
-                                    "value": "GDPR sensitive test notes for child",
-                                },
                             ],
                             "key": "CHILD",
                         }


### PR DESCRIPTION
## Description

### refactor: move named GraphQL query/mutation variables to own files

what was done (and nothing else):
 - moved GraphQL queries, that were in variables, to queries.py in order of their appearance in the original source file
 - moved GraphQL mutations, that were in variables, to mutations.py in order of their appearance in the original source file
 - imported the moved queries from queries.py
 - imported the moved mutations from mutations.py

NOTE:
 - variables to queries/mutations were NOT moved but left where they were in the original source file

refs KK-1143 (refactoring came up in code review discussion)

## Related

[KK-1143](https://helsinkisolutionoffice.atlassian.net/browse/KK-1143)

[KK-1143]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ