### PR TITLE
fix: add env-variable for GDPR API authorization field

### DIFF
--- a/.env.keycloak.example
+++ b/.env.keycloak.example
@@ -1,0 +1,21 @@
+DEBUG=1
+DATABASE_URL=postgres://kukkuu:kukkuu@localhost:5434/kukkuu
+CORS_ORIGIN_WHITELIST=http://localhost:3000,http://localhost:3001,http://localhost:3002
+CORS_ORIGIN_ALLOW_ALL=True
+TOKEN_AUTH_AUTHSERVER_URL=https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus
+# For local Kukkuu API:
+TOKEN_AUTH_ACCEPTED_AUDIENCE=kukkuu-api-dev,profile-api-test
+# For test env Kukkuu API:
+# TOKEN_AUTH_ACCEPTED_AUDIENCE=kukkuu-api-test,profile-api-test
+TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX=
+TOKEN_AUTH_REQUIRE_SCOPE_PREFIX=False
+GDPR_API_QUERY_SCOPE=gdprquery
+GDPR_API_DELETE_SCOPE=gdprdelete
+GDPR_API_AUTHORIZATION_FIELD=authorization.permissions.scopes
+HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED=True
+KUKKUU_HASHID_SALT=abcdefg123456
+KUKKUU_TICKET_VERIFICATION_URL=http://localhost:3000/ticket-verification-endpoint/{reference_id}
+MAIL_MAILGUN_KEY
+MAIL_MAILGUN_DOMAIN=hel.fi
+MAIL_MAILGUN_API=https://api.eu.mailgun.net/v3
+KUKKUU_NOTIFICATIONS_SHEET_ID=1TkdQsO50DHOg5pi1JhzudOL1GKpiK-V2DCIoAipKj-M

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -75,11 +75,13 @@ env = environ.Env(
     # for `GDPR_API_QUERY_SCOPE` and `GDPR_API_DELETE_SCOPE`.
     GDPR_API_QUERY_SCOPE=(str, "kukkuu.gdprquery"),
     GDPR_API_DELETE_SCOPE=(str, "kukkuu.gdprdelete"),
-    # NOTE: For a Keycloak, the following variables might be needed
+    GDPR_API_AUTHORIZATION_FIELD=(str, "https://api.hel.fi/auth"),
+    # NOTE: For a Keycloak, the following GDPR variables are needed
     # TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX=(str, ""),
     # TOKEN_AUTH_REQUIRE_SCOPE_PREFIX=(bool, False),
     # GDPR_API_QUERY_SCOPE=(str, "gdprquery"),
     # GDPR_API_DELETE_SCOPE=(str, "gdprdelete"),
+    # GDPR_API_AUTHORIZATION_FIELD=(str, "authorization.permissions.scopes"),
     HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED=(bool, False),
 )
 
@@ -352,6 +354,7 @@ GDPR_API_MODEL_LOOKUP = "uuid"
 GDPR_API_URL_PATTERN = "v1/user/<uuid:uuid>"
 GDPR_API_USER_PROVIDER = "gdpr.service.get_user"
 GDPR_API_DELETER = "gdpr.service.clear_data"
+GDPR_API_AUTHORIZATION_FIELD = env("GDPR_API_AUTHORIZATION_FIELD")
 
 HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED = env("HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED")
 


### PR DESCRIPTION
KK-1159.

Added an env-variable to set the `GDPR_API_AUTHORIZATION_FIELD`. The actual env specifiv value is set in the [pipeline configuration](https://dev.azure.com/City-of-Helsinki/kukkuu/_git/kukkuu-pipelines/pullrequest/8683).