### PR TITLE
KK-1175 | feat: always use user's email in SubmitChildrenAndGuardianMutation

### DIFF
--- a/children/schema.py
+++ b/children/schema.py
@@ -405,14 +405,23 @@ class SubmitChildrenAndGuardianMutation(graphene.relay.ClientIDMutation):
 
         guardian_data = kwargs["guardian"]
         languages_spoken_at_home = guardian_data.pop("languages_spoken_at_home", [])
+
+        # Override inexistent/empty guardian email with user email
+        if not guardian_data.get("email", None):
+            guardian_data["email"] = user.email
+
         validate_guardian_data(guardian_data)
+
+        if guardian_data.get("email", None) != user.email:
+            raise ApiUsageError("Guardian email must be the same as user email.")
+
         guardian = Guardian.objects.create(
             user=user,
             first_name=guardian_data["first_name"],
             last_name=guardian_data["last_name"],
             phone_number=guardian_data.get("phone_number", ""),
             language=guardian_data["language"],
-            email=guardian_data.get("email", ""),
+            email=guardian_data["email"],
             has_accepted_communication=guardian_data.get(
                 "has_accepted_communication", False
             ),

--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -476,7 +476,7 @@ snapshots["test_submit_children_and_guardian 1"] = {
     }
 }
 
-snapshots["test_submit_children_and_guardian_with_email 1"] = {
+snapshots["test_submit_children_and_guardian_with_falsy_email[None] 1"] = {
     "data": {
         "submitChildrenAndGuardian": {
             "children": [
@@ -489,7 +489,7 @@ snapshots["test_submit_children_and_guardian_with_email 1"] = {
                             {
                                 "node": {
                                     "guardian": {
-                                        "email": "updated_email@example.com",
+                                        "email": "michellewalker@example.net",
                                         "firstName": "Gulle",
                                         "lastName": "Guardian",
                                         "phoneNumber": "777-777777",
@@ -509,7 +509,7 @@ snapshots["test_submit_children_and_guardian_with_email 1"] = {
                             {
                                 "node": {
                                     "guardian": {
-                                        "email": "updated_email@example.com",
+                                        "email": "michellewalker@example.net",
                                         "firstName": "Gulle",
                                         "lastName": "Guardian",
                                         "phoneNumber": "777-777777",
@@ -522,7 +522,175 @@ snapshots["test_submit_children_and_guardian_with_email 1"] = {
                 },
             ],
             "guardian": {
-                "email": "updated_email@example.com",
+                "email": "michellewalker@example.net",
+                "firstName": "Gulle",
+                "languagesSpokenAtHome": {"edges": []},
+                "lastName": "Guardian",
+                "phoneNumber": "777-777777",
+            },
+        }
+    }
+}
+
+snapshots["test_submit_children_and_guardian_with_falsy_email[] 1"] = {
+    "data": {
+        "submitChildrenAndGuardian": {
+            "children": [
+                {
+                    "birthyear": 2020,
+                    "name": "Matti",
+                    "postalCode": "00840",
+                    "relationships": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "guardian": {
+                                        "email": "michellewalker@example.net",
+                                        "firstName": "Gulle",
+                                        "lastName": "Guardian",
+                                        "phoneNumber": "777-777777",
+                                    },
+                                    "type": "OTHER_GUARDIAN",
+                                }
+                            }
+                        ]
+                    },
+                },
+                {
+                    "birthyear": 2020,
+                    "name": "Jussi",
+                    "postalCode": "00820",
+                    "relationships": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "guardian": {
+                                        "email": "michellewalker@example.net",
+                                        "firstName": "Gulle",
+                                        "lastName": "Guardian",
+                                        "phoneNumber": "777-777777",
+                                    },
+                                    "type": None,
+                                }
+                            }
+                        ]
+                    },
+                },
+            ],
+            "guardian": {
+                "email": "michellewalker@example.net",
+                "firstName": "Gulle",
+                "languagesSpokenAtHome": {"edges": []},
+                "lastName": "Guardian",
+                "phoneNumber": "777-777777",
+            },
+        }
+    }
+}
+
+snapshots["test_submit_children_and_guardian_with_user_email 1"] = {
+    "data": {
+        "submitChildrenAndGuardian": {
+            "children": [
+                {
+                    "birthyear": 2020,
+                    "name": "Matti",
+                    "postalCode": "00840",
+                    "relationships": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "guardian": {
+                                        "email": "michellewalker@example.net",
+                                        "firstName": "Gulle",
+                                        "lastName": "Guardian",
+                                        "phoneNumber": "777-777777",
+                                    },
+                                    "type": "OTHER_GUARDIAN",
+                                }
+                            }
+                        ]
+                    },
+                },
+                {
+                    "birthyear": 2020,
+                    "name": "Jussi",
+                    "postalCode": "00820",
+                    "relationships": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "guardian": {
+                                        "email": "michellewalker@example.net",
+                                        "firstName": "Gulle",
+                                        "lastName": "Guardian",
+                                        "phoneNumber": "777-777777",
+                                    },
+                                    "type": None,
+                                }
+                            }
+                        ]
+                    },
+                },
+            ],
+            "guardian": {
+                "email": "michellewalker@example.net",
+                "firstName": "Gulle",
+                "languagesSpokenAtHome": {"edges": []},
+                "lastName": "Guardian",
+                "phoneNumber": "777-777777",
+            },
+        }
+    }
+}
+
+snapshots["test_submit_children_and_guardian_without_email 1"] = {
+    "data": {
+        "submitChildrenAndGuardian": {
+            "children": [
+                {
+                    "birthyear": 2020,
+                    "name": "Matti",
+                    "postalCode": "00840",
+                    "relationships": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "guardian": {
+                                        "email": "michellewalker@example.net",
+                                        "firstName": "Gulle",
+                                        "lastName": "Guardian",
+                                        "phoneNumber": "777-777777",
+                                    },
+                                    "type": "OTHER_GUARDIAN",
+                                }
+                            }
+                        ]
+                    },
+                },
+                {
+                    "birthyear": 2020,
+                    "name": "Jussi",
+                    "postalCode": "00820",
+                    "relationships": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "guardian": {
+                                        "email": "michellewalker@example.net",
+                                        "firstName": "Gulle",
+                                        "lastName": "Guardian",
+                                        "phoneNumber": "777-777777",
+                                    },
+                                    "type": None,
+                                }
+                            }
+                        ]
+                    },
+                },
+            ],
+            "guardian": {
+                "email": "michellewalker@example.net",
                 "firstName": "Gulle",
                 "languagesSpokenAtHome": {"edges": []},
                 "lastName": "Guardian",


### PR DESCRIPTION
## Description

## feat: always use user's email in SubmitChildrenAndGuardianMutation

change SubmitChildrenAndGuardianMutation's email validation behavior:
 - no input email -> use user's email
 - empty input email -> use user's email
 - non-empty input email different from user's email -> error
 - non-empty input email same as user's email -> ok

refs KK-1175

## Closes

[KK-1175](https://helsinkisolutionoffice.atlassian.net/browse/KK-1175)

[KK-1175]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Related

kukkuu-ui changes:
 - https://github.com/City-of-Helsinki/kukkuu-ui/pull/567