### PR TITLE
chore: increase the buffer-size for uWSGI

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -11,3 +11,4 @@ processes = 2
 threads = 2
 route = ^/readiness$ donotlog:
 route = ^/healthz$ donotlog:
+buffer-size = 65535 # Allow bigger requests that includes a big list of AD-groups. Default is 4096.


### PR DESCRIPTION
KK-1157.

Increasing the buffer-size will allow bigger requests which will allow e.g. to include big lists of AD-group memberships in a authentication token.

Refs
https://github.com/City-of-Helsinki/linkedevents/commit/1bd9ca89acc3f7f2becb70ce3b1b90faca67dc8c