### PR TITLE
fix: improve the django_mailer admin list display view

### DIFF
--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -200,6 +200,7 @@ INSTALLED_APPS = [
     "parler",
     "anymail",
     "mailer",
+    "kukkuu_mailer",  # must be after `mailer`, since it overrides admin
     "django_ilmoitin",
     "django_filters",
     "guardian",

--- a/kukkuu_mailer/admin.py
+++ b/kukkuu_mailer/admin.py
@@ -1,0 +1,56 @@
+from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
+from mailer.admin import MessageLogAdmin, show_to
+from mailer.models import MessageLog, RESULT_CODES
+
+
+def custom_titled_filter(title: str):
+    """A decorator to change a Django list filter title."""
+
+    class Wrapper(admin.FieldListFilter):
+        def __new__(cls, *args, **kwargs):
+            instance = admin.FieldListFilter.create(*args, **kwargs)
+            instance.title = title
+            return instance
+
+    return Wrapper
+
+
+def sent_to_mail_server(message: MessageLog) -> str:
+    """Override the result column in `list_display`.
+    A `list_display` column can be overridden by redefining
+    a `short_description`
+
+    @example
+    sent_to_mail_server.short_description = "Sent to mail server"
+
+    Args:
+        message (MessageLog): related MessageLog instance
+
+    Returns:
+        str: text for the value of the result field.
+    """
+    return next(text for (code, text) in RESULT_CODES if code == message.result)
+
+
+sent_to_mail_server.short_description = _("Sent to mail server")
+
+
+class KukkuuMessageLogAdmin(MessageLogAdmin):
+    """Override the MessageLogAdmin provided by django_mailer."""
+
+    list_display = [
+        "id",
+        show_to,
+        "subject",
+        "message_id",
+        "when_attempted",
+        sent_to_mail_server,  # Result column label changed
+    ]
+    list_filter = [("result", custom_titled_filter(_("Sent to mail server")))]
+
+
+# Unregister the MessageLog admin provided by the `django_mailer`.
+admin.site.unregister(MessageLog)
+# Register a new admin for the MessageLog.
+admin.site.register(MessageLog, KukkuuMessageLogAdmin)


### PR DESCRIPTION
KK-1172.

Rename the django_mailer result-column in a list_display view.

1. The column title for the result field has been changed.
2. The list filter title for the result field has been changed. 

NOTE: In order to override any admin site classes, a new django app must be added in the INSTALLED_APPS settings after the app that is being overridden.

<img width="1780" alt="image" src="https://github.com/City-of-Helsinki/kukkuu/assets/389204/1502d215-6c25-4657-9686-e1d5999b201d">
