### PR TITLE
fix: children event history markdown line endings and indentations

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -22,3 +22,4 @@ drf-spectacular
 hashids
 qrcode
 helsinki-profile-gdpr-api
+markdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -132,6 +132,8 @@ helsinki-profile-gdpr-api==0.2.0
     # via -r requirements.in
 idna==3.2
     # via requests
+importlib-metadata==7.1.0
+    # via markdown
 inflection==0.5.1
     # via drf-spectacular
 isodate==0.6.0
@@ -142,6 +144,8 @@ jsonschema==4.2.1
     # via drf-spectacular
 lockfile==0.12.2
     # via django-mailer
+markdown==3.6
+    # via -r requirements.in
 markupsafe==2.0.1
     # via jinja2
 msrest==0.6.21
@@ -237,6 +241,8 @@ urllib3==1.26.7
     # via
     #   requests
     #   sentry-sdk
+zipp==3.19.2
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+import markdown
 from django import forms
 from django.conf import settings
 from django.contrib import admin
@@ -66,7 +67,7 @@ def _generate_children_event_history_markdown(
         guardian,
         AuthServiceNotificationService.generate_children_event_history_markdown(
             guardian=guardian
-        ).replace("\n", "<br/>"),
+        ),
     )
 
 
@@ -76,7 +77,9 @@ def generate_children_event_history_markdown(modeladmin, request, queryset):
         guardian,
         children_event_history_markdown,
     ) = _generate_children_event_history_markdown(modeladmin, request, queryset)
-    return HttpResponse(children_event_history_markdown)
+    # Use markdown rendered to render this admin view,
+    # so the actual end result can be validated.
+    return HttpResponse(markdown.markdown(children_event_history_markdown))
 
 
 def _generate_user_auth_service_is_changing_notification_text(
@@ -109,9 +112,13 @@ def _generate_user_auth_service_is_changing_notification_text(
         template, context, language
     )
 
-    return USER_AUTH_SERVICE_IS_CHANGING_NOTIFICATION_TEMPLATE.format(
-        subject=subject, body_text=body_text
-    ).replace("\n", "<br/>")
+    # use <pre> to define that the text is preformatted,
+    # so the line breaks and indentations works properly.
+    return "<pre>{email_content}</pre>".format(
+        email_content=USER_AUTH_SERVICE_IS_CHANGING_NOTIFICATION_TEMPLATE.format(
+            subject=subject, body_text=body_text
+        )
+    )
 
 
 @admin.action(

--- a/users/services.py
+++ b/users/services.py
@@ -62,9 +62,14 @@ class GuardianEmailChangeNotificationService:
 
 CHILDREN_EVENT_HISTORY_MARKDOWN_TEMPLATE = """
 {% for child in guardian.children.all %}# {{ child.name }}
-{% for enrolment in child.enrolments.all|dictsort:"occurrence.time" %}{{ forloop.counter }}. **{{ enrolment.occurrence.event.name }}:** {{ enrolment.occurrence.time|date:"j.n.Y H:i" }}{% if enrolment.occurrence.event.short_description %}
-{{enrolment.occurrence.event.short_description}}{% endif %}
+
+{% for enrolment in child.enrolments.all|dictsort:"occurrence.time" %}
+{{ forloop.counter }}. **{{ enrolment.occurrence.event.name }}:** {{ enrolment.occurrence.time|date:"j.n.Y H:i" }}{% if enrolment.occurrence.event.short_description %}
+
+    {{enrolment.occurrence.event.short_description}}
+{% endif %}
 {% endfor %}
+
 {% endfor %}
 """  # noqa E501
 

--- a/users/tests/snapshots/snap_test_notifications.py
+++ b/users/tests/snapshots/snap_test_notifications.py
@@ -58,16 +58,30 @@ Occurrence: 1974-05-30 15:30:48+00:00
 
 Markdown: 
 # Jason Berg
+
+
 1. **Affect money school military statement.:** 2.2.1972 00:06
-Peace mean education college daughter.
+
+    Peace mean education college daughter.
+
+
 2. **Enjoy when one wonder fund nor white.:** 5.1.2011 10:35
-Sort deep phone such water price including.
+
+    Sort deep phone such water price including.
+
+
 
 # Katherine Gomez
+
+
 1. **Data table TV minute. Agree room laugh prevent make.:** 2.4.1971 07:11
-Enter everything history remember stay public high.
+
+    Enter everything history remember stay public high.
+
+
 2. **Include and individual effort indeed discuss challenge school.:** 30.5.1974 17:30
-Second know say former conference carry factor.
+
+    Second know say former conference carry factor.
 """
 ]
 

--- a/users/tests/snapshots/snap_test_services.py
+++ b/users/tests/snapshots/snap_test_services.py
@@ -9,12 +9,24 @@ snapshots = Snapshot()
 snapshots[
     "test_generate_children_event_history_markdown_with_data 1"
 ] = """# Jason Berg
+
+
 1. **Event 3 for child2:** 16.6.2023 00:00
-Staff country actually generation five training.
+
+    Staff country actually generation five training.
+
+
 2. **Event 4 for child2:** 6.12.2023 00:00
-Voice radio happen color scene. Create state rock only.
+
+    Voice radio happen color scene. Create state rock only.
+
+
 3. **Event 2 for child2:** 24.12.2023 00:00
 
+
 # Katherine Gomez
+
+
 1. **Event 1 for child1:** 1.1.2024 00:00
-Data table TV minute. Agree room laugh prevent make."""
+
+    Data table TV minute. Agree room laugh prevent make."""


### PR DESCRIPTION
KK-1183.
Fix the multiline list items markdown rendering.
Installed markdown library to render actual markdown with the admin action.

Markdown spec for multiline list items and more:
https://daringfireball.net/projects/markdown/syntax#list.


# Admin markdown generator:

✅ The list item is a multiline item with event short description on 2nd line.
✅ Each enrolment is a one list item

<img width="1200" alt="Screenshot 2024-06-13 at 10 40 02" src="https://github.com/City-of-Helsinki/kukkuu/assets/389204/ab552576-6577-4651-95d2-8c0777a4f3ba">

# Admin email text generator:

✅ The short description is indented (because in markdown it means that the list item has second line and it is rendered as P-tag.)
✅ The email should look good and human readable even without the markdown renderer.

<img width="1483" alt="Screenshot 2024-06-13 at 10 49 29" src="https://github.com/City-of-Helsinki/kukkuu/assets/389204/5f18dbd5-f321-4d16-b7e3-a6d2175d81bc">

# Admin email text generator markdown in Kukkuu UI markdown editor:

✅ The markdown is parsed properly

<img width="1478" alt="Screenshot 2024-06-13 at 11 33 27" src="https://github.com/City-of-Helsinki/kukkuu/assets/389204/0e272920-f5c1-4e9c-8b5c-c209d8574bba">
<img width="1493" alt="Screenshot 2024-06-13 at 11 33 54" src="https://github.com/City-of-Helsinki/kukkuu/assets/389204/04f15a28-e7fc-49c8-ad3c-d8cd6b05074d">

