### PR TITLE
KK-1184 | feat: add --obsolete_handled_users & --batch_size to auth change command

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -179,9 +179,8 @@ def send_user_auth_service_is_changing_notification(modeladmin, request, queryse
 def obsolete_and_send_user_auth_service_is_changing_notification(
     modeladmin, request, queryset
 ):
-    queryset.update(is_obsolete=True)
     AuthServiceNotificationService.send_user_auth_service_is_changing_notifications(
-        guardians=queryset, date_of_change_str=None
+        guardians=queryset, date_of_change_str=None, obsolete_handled_users=True
     )
 
 


### PR DESCRIPTION
## Description

### feat: add --obsolete_handled_users & --batch_size to auth change command

send_user_auth_service_is_changing_notifications management command:
 - "-o" / "--obsolete_handled_users":
   - will obsolete the handled users i.e. set their User model's
	 is_obsolete values to True, defaults to False
 - "b <int>" / "--batch_size <int>":
   - will use the batch size for bulk updating users and guardian
	 queryset iteration, defaults to 1000

refs KK-1184

## Closes

[KK-1184](https://helsinkisolutionoffice.atlassian.net/browse/KK-1184)

[KK-1184]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ