### PR TITLE
fix: improve event and event group admins with safegetters and searches

### DIFF
--- a/browser-tests/tests/initialData.ts
+++ b/browser-tests/tests/initialData.ts
@@ -1,50 +1,34 @@
-import {
-  testUsername,
-  testUserPassword,
-} from './utils/settings';
+import { testUsername, testUserPassword } from "./utils/settings";
 
-import {
-  event,
-  createNew as createNewEvent
-} from './pages/event';
-import {
-  createNew as createNewOccurence,
-} from './pages/occurence';
+import { event, createNew as createNewEvent } from "./pages/event";
+import { createNew as createNewOccurence } from "./pages/occurence";
 import {
   eventGroup,
   publish as publishEventGroup,
-  createNew as createNewEventGroup
-} from './pages/eventGroup';
-import {
-  projectExists,
-  project,
-} from './pages/project';
-import {
-  venue,
-  venueExists,
-} from './pages/venue';
+  createNew as createNewEventGroup,
+} from "./pages/eventGroup";
+import { projectExists, project } from "./pages/project";
+import { venue, venueExists } from "./pages/venue";
 
-import { createNewMessage } from './pages/message';
-import { userExists } from './pages/user';
-import { route as routeHome } from './pages/home';
+import { createNewMessage } from "./pages/message";
+import { userExists } from "./pages/user";
+import { route as routeHome } from "./pages/home";
 
-import { login } from './utils/login';
+import { login } from "./utils/login";
 
-fixture`Event group feature`
-  .page(routeHome())
-  .beforeEach(async (t) => {
-    await login(t, {
-      username: testUsername(),
-      password: testUserPassword(),
-    });
-    await t.wait(1000);
-
-    await projectExists(t);
-    await venueExists(t);
+fixture`Event group feature`.page(routeHome()).beforeEach(async (t) => {
+  await login(t, {
+    username: testUsername(),
+    password: testUserPassword(),
   });
+  await t.wait(1000);
 
-test('Add initial data for ui and admin ui tests', async (t) => {
-  const projectName = `${project.name} ${project.year}`;
+  await projectExists(t);
+  await venueExists(t);
+});
+
+test("Add initial data for ui and admin ui tests", async (t) => {
+  const projectName = new RegExp(`${project.year}$`);
 
   // add new event group
   await createNewEventGroup(t, projectName);

--- a/browser-tests/tests/pages/event.ts
+++ b/browser-tests/tests/pages/event.ts
@@ -32,7 +32,7 @@ export const routeAdd = () => `${envUrl()}/admin/events/event/add`;
 // fill add form for new event
 export const fillFormAdd = async (
   t: TestController,
-  projectName: string,
+  projectName: string | RegExp,
   eventGroupName: string
 ) => {
   const eventGroupOption = eventAdd.eventGroup.find("option");
@@ -56,7 +56,7 @@ export const fillFormAdd = async (
 // create new event
 export const createNew = async (
   t: TestController,
-  projectName: string,
+  projectName: string | RegExp,
   eventGroupName: string
 ) => {
   await t.navigateTo(routeAdd());

--- a/browser-tests/tests/pages/eventGroup.ts
+++ b/browser-tests/tests/pages/eventGroup.ts
@@ -31,7 +31,7 @@ export const publish = async (t: TestController) => {
   await t.navigateTo(route());
 
   // checkbox on event group row
-  const selectCheckbox = Selector(".field-name")
+  const selectCheckbox = Selector(".field-name_with_fallback")
     .withText(eventGroup.name)
     .parent("tr")
     .child(".action-checkbox")
@@ -48,7 +48,10 @@ export const publish = async (t: TestController) => {
 };
 
 // fill add form for new event group
-export const fillFormAdd = async (t: TestController, projectName: string) => {
+export const fillFormAdd = async (
+  t: TestController,
+  projectName: string | RegExp
+) => {
   await t
     .click(eventGroupAdd.project)
     .click(getDropdownOption(projectName))
@@ -57,7 +60,10 @@ export const fillFormAdd = async (t: TestController, projectName: string) => {
 };
 
 // create new event group
-export const createNew = async (t: TestController, projectName: string) => {
+export const createNew = async (
+  t: TestController,
+  projectName: string | RegExp
+) => {
   await t.navigateTo(routeAdd());
 
   await fillFormAdd(t, projectName);

--- a/browser-tests/tests/pages/message.ts
+++ b/browser-tests/tests/pages/message.ts
@@ -25,7 +25,7 @@ export const routeAdd = () => `${envUrl()}/admin/messaging/message/add/`;
 // fill add form for new message
 export const fillFormAdd = async (
   t: TestController,
-  projectName: string,
+  projectName: string | RegExp,
   eventName: string
 ) => {
   const eventOption = messageAdd.event.find("option");
@@ -49,7 +49,7 @@ export const fillFormAdd = async (
 // create new message
 export const createNewMessage = async (
   t: TestController,
-  projectName: string,
+  projectName: string | RegExp,
   eventName: string
 ) => {
   await t.navigateTo(routeAdd());

--- a/browser-tests/tests/pages/project.ts
+++ b/browser-tests/tests/pages/project.ts
@@ -22,7 +22,6 @@ export const routeAdd = () => `${envUrl()}/admin/projects/project/add/`;
 
 export const addProject = async (t: TestController) => {
   await t.navigateTo(routeAdd());
-
   await t
     .typeText(projectAdd.name, project.name)
     .typeText(projectAdd.year, year.toString())

--- a/browser-tests/tests/pages/venue.ts
+++ b/browser-tests/tests/pages/venue.ts
@@ -28,7 +28,7 @@ export const addVenue = async (t: TestController) => {
 
   await t
     .click(venueAdd.project)
-    .click(getDropdownOption(`${project.name} ${project.year}`))
+    .click(getDropdownOption(new RegExp(`${project.year}$`)))
     .typeText(venueAdd.name, venue.name)
     .typeText(venueAdd.description, venue.description)
     .click(venueAdd.saveButton);

--- a/browser-tests/tests/utils/getDropdownOption.ts
+++ b/browser-tests/tests/utils/getDropdownOption.ts
@@ -1,7 +1,7 @@
-import { screen } from '@testing-library/testcafe';
+import { screen } from "@testing-library/testcafe";
 
-function getDropdownOption(label: string) {
-  return screen.getByRole('option', { name: label });
+function getDropdownOption(label: string | RegExp) {
+  return screen.getByRole("option", { name: label });
 }
 
 export default getDropdownOption;


### PR DESCRIPTION
KK-1200. Fix event group admin.

1. Add an id as a "link column", since the name can sometimes be empty.
2. Add a fallback option for name and short descriptions in the list
display.
3. Add a missing search field that search for name and short
description.

KK-1201. Fix event admin.

Search by event and event group name.

