### PR TITLE
feat: add search and autocomplete fields to group and ad groups admin

### DIFF
--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -190,6 +190,7 @@ ENABLE_GRAPHIQL = env("ENABLE_GRAPHIQL")
 INSTALLED_APPS = [
     "helusers.apps.HelusersConfig",
     "helusers.apps.HelusersAdminConfig",
+    "kukkuu_helusers_admin",  # must be after `helusers`, since it overrides admin
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/kukkuu_helusers_admin/admin.py
+++ b/kukkuu_helusers_admin/admin.py
@@ -1,0 +1,26 @@
+from django.contrib import admin
+from helusers.admin import ADGroupMappingAdmin
+from helusers.models import ADGroup, ADGroupMapping
+
+
+class KukkuuADGroupAdmin(admin.ModelAdmin):
+    model = ADGroup
+    search_fields = ("name",)
+
+
+class KukkuuADGroupMappingAdmin(ADGroupMappingAdmin):
+    """Override the ADGroupMappingAdmin provided by helusers."""
+
+    search_fields = ("group__name", "ad_group__name", "ad_group__display_name")
+    autocomplete_fields = ("group", "ad_group")
+
+
+# Unregister the ADGroup admin provided by the `helusers`.
+admin.site.unregister(ADGroup)
+# Unregister the ADGroupMapping admin provided by the `helusers`.
+admin.site.unregister(ADGroupMapping)
+
+# Register a new admin for the ADGroupMapping.
+admin.site.register(ADGroup, KukkuuADGroupAdmin)
+# Register a new admin for the ADGroupMapping.
+admin.site.register(ADGroupMapping, KukkuuADGroupMappingAdmin)

--- a/kukkuu_helusers_admin/apps.py
+++ b/kukkuu_helusers_admin/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class KukkuuHelusersAdminConfig(AppConfig):
+    name = "kukkuu_helusers_admin"
+    verbose_name = _("Kukkuu helusers admin")

--- a/users/admin.py
+++ b/users/admin.py
@@ -314,6 +314,7 @@ admin.site.unregister(Group)
 class UserInline(admin.StackedInline):
     model = get_user_model().groups.through
     extra = 0
+    autocomplete_fields = ("user",)
 
 
 @admin.register(Group)


### PR DESCRIPTION
KK-1199.

Add a new django app to override `django_helusers` admin views:

1. Add search fields to AD-group,  group and AD-group-mappings administration.
2. Add autocomplete fields to AD-group-mappings admin form.
3. Add autocomplete field to Group admin's UserInLine

Autocomplete in Group admin form:

<img width="608" alt="image" src="https://github.com/City-of-Helsinki/kukkuu/assets/389204/0c5f5980-f951-4c48-8fc2-a876cb04f46f">

Autocomplete fields in AD-group mappings admin form:
<img width="516" alt="image" src="https://github.com/City-of-Helsinki/kukkuu/assets/389204/88516a34-f209-4aad-b3c9-35478c14c77c">
<img width="503" alt="image" src="https://github.com/City-of-Helsinki/kukkuu/assets/389204/b9f5e348-0163-4cfe-b366-e887006baf5d">

Search field in AD-group mappigns admin listing:
<img width="500" alt="image" src="https://github.com/City-of-Helsinki/kukkuu/assets/389204/5c5d62f1-febd-4e65-888b-e3ee86189a1d">

Search field in AD-group admin listing:
<img width="439" alt="image" src="https://github.com/City-of-Helsinki/kukkuu/assets/389204/87e63f28-7c1b-41a5-adca-a15505589072">

