### PR TITLE
feat: provide initial browser test data automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ ENV DEV_SERVER=1
 
 COPY --chown=default:root . /app/
 
+# fatal: detected dubious ownership in repository at '/app'
+RUN git config --system --add safe.directory /app
+
 USER default
 EXPOSE 8081/tcp
 
@@ -38,6 +41,9 @@ FROM appbase AS production
 # ==============================
 
 COPY --chown=default:root . /app/
+
+# fatal: detected dubious ownership in repository at '/app'
+RUN git config --system --add safe.directory /app
 
 RUN SECRET_KEY="only-used-for-collectstatic" KUKKUU_HASHID_SALT="only-used-for-collectstatic" python manage.py collectstatic
 

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -295,6 +295,13 @@ if OIDC_BROWSER_TEST_API_TOKEN_AUTH["ENABLED"]:
             "Set OIDC_BROWSER_TEST_API_TOKEN_AUTH['JWT_SIGN_SECRET']."
         )
 
+# The browser tests should be targeted for the users of this group.
+# If the group does not exist, it will be automatically created,
+# when the OIDC_BROWSER_TEST_API_TOKEN_AUTH["ENABLED"] is True.
+BROWSER_TEST_PROJECT_YEAR = 1234
+BROWSER_TEST_PROJECT_NAME = "Browser test"
+BROWSER_TEST_GROUP_NAME = BROWSER_TEST_PROJECT_NAME
+BROWSER_TEST_AD_GROUP_NAME = "kukkuu_browser_test"
 
 SITE_ID = 1
 

--- a/projects/apps.py
+++ b/projects/apps.py
@@ -1,0 +1,140 @@
+import logging
+
+from django.apps import AppConfig
+from django.conf import settings
+from django.db import transaction
+from django.db.models.signals import post_migrate
+from django.utils import translation
+
+logger = logging.getLogger(__name__)
+
+
+def _get_or_create_browser_test_group():
+    """
+    Gets or creates the Group object for browser tests.
+
+    Returns:
+        Group: The retrieved or created Group instance.
+    """
+    from django.contrib.auth.models import Group
+
+    # Group
+    group, _ = Group.objects.get_or_create(name=settings.BROWSER_TEST_GROUP_NAME)
+    logger.info(f"Group '{group}' retrieved or created.")
+    return group
+
+
+def _get_or_create_browser_test_ad_group():
+    """
+    Gets or creates the ADGroup object for browser tests.
+
+    Returns:
+        ADGroup: The retrieved or created ADGroup instance.
+    """
+    from helusers.models import ADGroup
+
+    # ADGroup (lowercase name and display_name)
+    ad_group_name = settings.BROWSER_TEST_AD_GROUP_NAME.lower()
+    ad_group, _ = ADGroup.objects.get_or_create(
+        name=ad_group_name, defaults={"display_name": ad_group_name}
+    )
+    logger.info(f"ADGroup '{ad_group}' retrieved or created.")
+    return ad_group
+
+
+def _get_or_create_browser_test_ad_group_mapping(ad_group, group):
+    """
+    Gets or creates the ADGroupMapping object for browser tests,
+    linking the given ADGroup and Group.
+
+    Args:
+        ad_group (ADGroup): The ADGroup instance to link.
+        group (Group): The Group instance to link.
+
+    Returns:
+        ADGroupMapping: The retrieved or created ADGroupMapping instance.
+    """
+    from helusers.models import ADGroupMapping
+
+    # ADGroupMapping
+    ad_group_mapping, _ = ADGroupMapping.objects.get_or_create(
+        ad_group=ad_group, group=group
+    )
+    logger.info(f"ADGroupMapping '{ad_group_mapping}' retrieved or created.")
+    return ad_group_mapping
+
+
+def _get_or_create_browser_test_project():
+    """
+    Gets or creates the Project object for browser tests,
+    ensuring the correct translated name.
+
+    Returns:
+        Project: The retrieved or created Project instance.
+    """
+    from projects.models import Project
+
+    # Activate default language before accessing translated fields
+    translation.activate(settings.LANGUAGE_CODE)
+
+    try:
+        # Project (check for name updates)
+        project, _ = Project.objects.get_or_create(
+            year=settings.BROWSER_TEST_PROJECT_YEAR,
+            defaults={"translation__name": settings.BROWSER_TEST_PROJECT_NAME},
+        )
+        logger.info(f"Project '{project}' retrieved or created.")
+
+        return project
+
+    finally:
+        # Deactivate language after using translated fields
+        translation.deactivate()
+
+
+def _set_group_project_permissions(project, group):
+    """
+    Assigns the required project permissions to the given Group
+    for the specified Project.
+
+    Args:
+        project (Project): The Project instance to assign permissions for.
+        group (Group): The Group to which permissions should be granted.
+    """
+    from guardian.shortcuts import assign_perm
+
+    from projects.models import Project
+
+    project_perms = [
+        f"projects.{project_perm[0]}" for project_perm in Project._meta.permissions
+    ]
+    for perm in project_perms:
+        try:
+            assign_perm(perm, group, project)
+            logger.info(
+                f"Assigned permission '{perm}' to project {project} for group {group}."
+            )
+        except Exception as e:  # Catch specific permission-related exceptions
+            logger.error(f"Error assigning permission '{perm}': {e}")
+
+
+@transaction.atomic()
+def create_browser_test_resources(sender, **kwargs):
+    """Creates Group, ADGroup, and Project resources for browser tests."""
+
+    if not settings.OIDC_BROWSER_TEST_API_TOKEN_AUTH["ENABLED"]:
+        return
+
+    group = _get_or_create_browser_test_group()
+    ad_group = _get_or_create_browser_test_ad_group()
+    _get_or_create_browser_test_ad_group_mapping(ad_group=ad_group, group=group)
+    project = _get_or_create_browser_test_project()
+
+    _set_group_project_permissions(project=project, group=group)
+
+
+class ProjectsConfig(AppConfig):
+    name = "projects"
+
+    def ready(self):
+        post_migrate.connect(create_browser_test_resources, sender=self)


### PR DESCRIPTION
KK-1168.

Create Group, ADGroup, and Project resources for browser tests. This is done in the project app's ready-function and with a post_migrate -signal.

In Django, the post_migrate signal is emitted in the following scenarios:

After Migrations: It is triggered immediately after Django successfully applies migrations to your database. This includes both initial migrations when setting up your project and subsequent migrations when you make changes to your models.

During Tests (with --keepdb): If you run your Django tests with the --keepdb flag, the post_migrate signal will also be triggered after the test database is initialized. However, if you use a separate test database for each test case, the signal might be emitted for each test.

Management Commands: Some Django management commands, like createsuperuser, might also trigger the post_migrate signal if migrations need to be applied beforehand.