### PR TITLE
fix: link and subject field in the messaging admin list display

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -280,7 +280,7 @@ class EventGroupAdmin(TranslatableAdmin):
         but if the browser is using some other locale than what is set as a default
         in the Django, then there might be some missing translations,
         because the Kukkuu and Kukkuu Admin UI has been empty string to
-        untranslated fields. This uses the ddefault language ("fi") in cases
+        untranslated fields. This uses the default language ("fi") in cases
         when the current active language returns an empty string.
 
         Args:


### PR DESCRIPTION
KK-1212.

Improves the https://github.com/City-of-Helsinki/kukkuu/pull/390/files#diff-c327ae44d42381dc0896cb42446dbdfd7a515a48ae6b0bfb4a971941c007c44b by fixing the subject and link field.

Fixing this situation when the current locale does not have a subject:

![image](https://github.com/user-attachments/assets/e30af884-f0f5-4971-a673-104f5f9a8a48)

with this

<img width="1222" alt="image" src="https://github.com/user-attachments/assets/6bf74121-8a23-4aa1-af92-2e15f7bf70e5">
