### PR TITLE
chore: configure gitlint to be more lenient & add notes to README.md

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,24 @@
-[title-max-length] 
-line-length=50
+[general]
+# Match anywhere (search) instead of just at the beginning of the line
+# https://jorisroovers.github.io/gitlint/configuration/#regex-style-search
+regex-style-search=true
+
+[title-max-length]
+line-length=72
+
+[ignore-body-lines]
+# Ignore all lines containing >72 character http:// or https:// URLs
+# because URLs can not be easily wrapped to multiple lines without
+# breaking them somehow.
+#
+# Explanation of the regular expression:
+#
+# "(?=\S{73,})" uses a positive lookahead with 73 non-whitespace characters
+# which means there must be at least 73 non-whitespace characters ahead.
+# It doesn't change the position in input string though. So if there are at
+# least 73 non-whitespace characters ahead then those must start with
+# either "http://" or "https://".
+regex=^.*(?=\S{73,})(http://|https://)
 
 [title-min-length]
 min-length=3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 # Ruff pre-commit hook documentation:
 # - https://github.com/astral-sh/ruff-pre-commit
 default_language_version:
-  python: python3.9
+  python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version
@@ -26,3 +26,4 @@ repos:
     rev:  v0.19.1
     hooks:
       -   id: gitlint
+          stages: [commit-msg]

--- a/README.md
+++ b/README.md
@@ -204,9 +204,12 @@ You can use [`pre-commit`](https://pre-commit.com/) to lint and format your code
 1. Install `pre-commit` (there are many ways to do but let's use pip as an example):
    - `pip install pre-commit`
 2. Set up git hooks from `.pre-commit-config.yaml`, run this command from project root:
-   - `pre-commit install`
+   - `pre-commit install` for code formatting & linting
+   - `pre-commit install --hook-type commit-msg` for commit message linting
 
 After that, linting and formatting hooks will run against all changed files before committing.
+
+Git commit message linting is configured in [.gitlint](./.gitlint)
 
 ## Issues board
 


### PR DESCRIPTION
## Description

### chore: configure gitlint to be more lenient & add notes to README.md

relaxed gitlint rules:
 - allowing 72 character long titles instead of 50 to be more lenient
 - allowing >72 character http and https URLs in git commit messages,
   e.g. https://www.example.org/this-is-a-very-long-url-that-can-not-be-split-without-breaking-it-somehow

also:
 - update default python version in pre commit config from 3.9 to 3.11
 - add general.regex-style-search=true to gitlint configuration so
   gitlint doesn't show a warning about it (See below)

gitlint's warning about regex match/search semantics:
```
gitlint will be switching from using Python regex 'match' (match
beginning) to 'search' (match anywhere) semantics. Please review your
ignore-by-title.regex option accordingly. To remove this warning, set
general.regex-style-search=True. More details:
https://jorisroovers.github.io/gitlint/configuration/#regex-style-search
```

refs KK-1234

## Related

- [KK-1234](https://helsinkisolutionoffice.atlassian.net/browse/KK-1234)
- PR #418 

## Manual testing

Tested locally that e.g. long URLs passed and that non-URL >72 character git commit message lines did not
in the pre commit hook stage.

[KK-1234]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ