### PR TITLE
fix: upgrade django-ilmoitin to fix migration issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ django-helusers==0.13.0
     # via
     #   -r requirements.in
     #   helsinki-profile-gdpr-api
-django-ilmoitin==0.7.0
+django-ilmoitin==0.7.1
     # via -r requirements.in
 django-mailer==2.3.2
     # via django-ilmoitin


### PR DESCRIPTION
KK-1246.

A proposed fix
https://github.com/City-of-Helsinki/django-ilmoitin/pull/42 was released in django-ilmoitin 0.7.1.

The missing migrations were applied to kukkuu with `python manage.py migrate`.

```
  Applying
django_ilmoitin.0006_alter_notificationtemplatetranslation_id... OK
  Applying
django_ilmoitin.0007_alter_notificationtemplate_admins_to_notify... OK
```