### PR TITLE
test: add an option to run Testcafe test with chromium

### DIFF
--- a/browser-tests/package.json
+++ b/browser-tests/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint --ext js,ts,tsx src",
     "test:browser": "testcafe \"chrome --window-size='1920,1080'\" tests/ --live",
     "test:browser:wsl2win": "testcafe 'path:`/mnt/c/Program Files/Google/Chrome/Application/chrome.exe`' tests/ --live --dev",
-    "test:browser:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" -s path=report,takeOnFails=true --video report --reporter spec,html:report/index.html tests/"
+    "test:browser:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" -s path=report,takeOnFails=true --video report --reporter spec,html:report/index.html tests/",
+    "test:browser:ci:chromium": "testcafe \"chromium:headless --disable-gpu --window-size='1920,1080'\" -s path=report,takeOnFails=true --video report --reporter spec,html:report/index.html tests/"
   },
   "browserslist": {
     "production": [
@@ -24,8 +25,7 @@
       "last 1 safari version"
     ]
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@testing-library/testcafe": "^5.0.0",


### PR DESCRIPTION
KK-1247.

Pipeline changes: https://dev.azure.com/City-of-Helsinki/kukkuu/_git/kukkuu-pipelines/pullrequest/9899

Add an option to run Testcafe browser tests with Chromium instead of
Chrome. There have been some issues with the Chrome that prevents using
it in CI environment:

- https://github.com/DevExpress/testcafe/issues/8286
- https://github.com/DevExpress/testcafe/issues/8300
- https://github.com/DevExpress/testcafe/issues/8304
- https://github.com/DevExpress/testcafe/issues/8307
