### PR TITLE
KK-1322 | Add hasAnyFreePasswords to ExternalEventTicketSystem

### DIFF
--- a/events/tests/queries.py
+++ b/events/tests/queries.py
@@ -388,6 +388,18 @@ query TicketSystemPasswordCounts($eventId: ID!) {
 }
 """
 
+EVENT_TICKET_SYSTEM_HAS_ANY_FREE_PASSWORDS_QUERY = """
+query TicketSystemHasAnyFreePasswords($eventId: ID!) {
+  event(id: $eventId) {
+    ticketSystem {
+      ... on TicketmasterEventTicketSystem {
+        hasAnyFreePasswords
+      }
+    }
+  }
+}
+"""
+
 
 VERIFY_TICKET_QUERY = """
   query VerifyTicket($referenceId: String!){


### PR DESCRIPTION
## Description

### feat: add hasAnyFreePasswords to ExternalEventTicketSystem

NOTE:
 - This field is available to all logged-in users, no anonymous
   access, but no project permission required either.

also:
 - add @staticmethod to all resolve functions (See below the Graphene
   documentation) in ExternalEventTicketSystem so SonarCloud doesn't
   complain about the first parameter not being `self` (i.e. "self"
   should be the first argument to instance methods python:S5720)

From Graphene documentation:
https://docs.graphene-python.org/en/latest/types/objecttypes/#resolverimplicitstaticmethod

> One surprising feature of Graphene is that all resolver methods are
> treated implicitly as staticmethods. This means that, unlike other
> methods in Python, the first argument of a resolver is never self
> while it is being executed by Graphene.

> If you prefer your code to be more explicit, feel free to use
> @staticmethod decorators. Otherwise, your code may be cleaner without
> them!

refs KK-1322

## Related

[KK-1322](https://helsinkisolutionoffice.atlassian.net/browse/KK-1322)

[KK-1322]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ