### PR TITLE
Test ruff is same in requirements-dev.txt and .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,11 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version
-    rev: v0.5.2
+    # NOTE: Don't move the trailing "ruff-pre-commit version" comment from
+    # the ruff's version line, it is used by test_pre_commit_ruff_version.py
+    # test case in order not to have to add a YAML library dependency just
+    # to test this version:
+    rev: v0.8.0  # ruff-pre-commit version
     hooks:
       # Run the linter
       - id: ruff

--- a/kukkuu/tests/test_pre_commit_ruff_version.py
+++ b/kukkuu/tests/test_pre_commit_ruff_version.py
@@ -1,0 +1,40 @@
+import re
+
+RUFF_VERSION_PRE_COMMIT_REGEX = re.compile(
+    r"rev: v(\d+(\.\d+)+)\s*# ruff-pre-commit version"
+)
+
+
+def get_ruff_version_from_dev_requirements() -> str | None:
+    with open("./requirements-dev.txt") as file:
+        dev_requirements = file.read()
+    for line in dev_requirements.splitlines():
+        if line.startswith("ruff=="):
+            return line.split("==")[1].strip()
+    return None
+
+
+def get_ruff_version_from_pre_commit_config() -> str | None:
+    with open("./.pre-commit-config.yaml") as file:
+        pre_commit_config = file.read()
+    for line in pre_commit_config.splitlines():
+        match = RUFF_VERSION_PRE_COMMIT_REGEX.search(line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def test_ruff_is_in_dev_requirements():
+    ruff_version_dev_requirements = get_ruff_version_from_dev_requirements()
+    assert ruff_version_dev_requirements is not None
+
+
+def test_ruff_is_in_pre_commit_config():
+    ruff_version_pre_commit = get_ruff_version_from_pre_commit_config()
+    assert ruff_version_pre_commit is not None
+
+
+def test_ruff_same_in_dev_requirements_and_pre_commit_config():
+    ruff_version_dev_requirements = get_ruff_version_from_dev_requirements()
+    ruff_version_pre_commit = get_ruff_version_from_pre_commit_config()
+    assert ruff_version_dev_requirements == ruff_version_pre_commit


### PR DESCRIPTION
## Description

### test: ruff is same in requirements-dev.txt and .pre-commit-config.yaml

also:
 - update ruff to same version in .pre-commit-config.yaml as it is in
   requirements-dev.txt, they were out of sync