### PR TITLE
KK-1357 | Fix warnings

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from datetime import timedelta
 from typing import Optional
 
@@ -209,20 +208,17 @@ class EventQueryset(TranslatableQuerySet):
 
     def available(self, child):
         """
+        Child's available events without checking yearly enrolment limits
+
         A child's available events must match all the following rules:
             * the event must be published
             * the event must have at least one occurrence in the future
             * the child must not have enrolled to the event
             * the child must not have enrolled to any event in the same event group
               as the event
-        """
 
-        warnings.warn(
-            "Query doesn't exclude events when yearly "
-            "limit of enrolments have been exceeded.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        :note: Does NOT take yearly enrolment limits into account
+        """
 
         child_enrolled_event_groups = EventGroup.objects.filter(
             events__occurrences__in=child.occurrences.all()

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -173,7 +173,6 @@ LANGUAGE_CODE = "fi"
 LANGUAGES = (("fi", _("Finnish")), ("en", _("English")), ("sv", _("Swedish")))
 TIME_ZONE = "Europe/Helsinki"
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 # Set to True to enable GraphiQL interface, this will overriden to True if DEBUG=True
 ENABLE_GRAPHIQL = env("ENABLE_GRAPHIQL")

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -54,7 +54,7 @@ env = environ.Env(
         ["https://tunnistus.test.hel.ninja/auth/realms/helsinkitunnistus"],
     ),
     ILMOITIN_QUEUE_NOTIFICATIONS=(bool, True),
-    DEFAULT_FILE_STORAGE=(str, "django.core.files.storage.FileSystemStorage"),
+    STORAGES_DEFAULT_BACKEND=(str, "django.core.files.storage.FileSystemStorage"),
     GS_BUCKET_NAME=(str, ""),
     STAGING_GCS_BUCKET_CREDENTIALS=(str, ""),
     GS_DEFAULT_ACL=(str, "publicRead"),
@@ -153,10 +153,10 @@ MEDIA_URL = env.str("MEDIA_URL")
 STATIC_URL = env.str("STATIC_URL")
 
 # For staging env, we use Google Cloud Storage
-DEFAULT_FILE_STORAGE = env("DEFAULT_FILE_STORAGE")
+STORAGES_DEFAULT_BACKEND = env("STORAGES_DEFAULT_BACKEND")
 
 # For prod, it's Azure Storage
-if DEFAULT_FILE_STORAGE == "storages.backends.azure_storage.AzureStorage":
+if STORAGES_DEFAULT_BACKEND == "storages.backends.azure_storage.AzureStorage":
     AZURE_ACCOUNT_NAME = env("AZURE_ACCOUNT_NAME")
     AZURE_CONTAINER = env("AZURE_CONTAINER")
     if env("AZURE_BLOB_STORAGE_SAS_TOKEN"):
@@ -165,6 +165,15 @@ if DEFAULT_FILE_STORAGE == "storages.backends.azure_storage.AzureStorage":
         AZURE_CONNECTION_STRING = f"{AZURE_ENDP};SharedAccessSignature={SAS_TOKEN};"
     else:
         AZURE_ACCOUNT_KEY = env("AZURE_ACCOUNT_KEY")
+
+STORAGES = {
+    "default": {
+        "BACKEND": STORAGES_DEFAULT_BACKEND,
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
 
 ROOT_URLCONF = "kukkuu.urls"
 WSGI_APPLICATION = "kukkuu.wsgi.application"

--- a/kukkuu/views.py
+++ b/kukkuu/views.py
@@ -150,12 +150,12 @@ class SentryGraphQLView(FileUploadGraphQLView):
         return result
 
     def _capture_sentry_exceptions(self, errors, query):
-        with sentry_sdk.configure_scope() as scope:
-            scope.set_extra("graphql_query", query)
-            for error in errors:
-                if hasattr(error, "original_error"):
-                    error = error.original_error
-                sentry_sdk.capture_exception(error)
+        scope = sentry_sdk.get_current_scope()
+        scope.set_extra("graphql_query", query)
+        for error in errors:
+            if hasattr(error, "original_error"):
+                error = error.original_error
+            sentry_sdk.capture_exception(error)
 
     @staticmethod
     def format_error(error):

--- a/venues/schema.py
+++ b/venues/schema.py
@@ -46,6 +46,22 @@ class VenueNode(DjangoObjectType):
     class Meta:
         model = Venue
         interfaces = (relay.Node,)
+        fields = (
+            "id",
+            "created_at",
+            "updated_at",
+            "name",
+            "description",
+            "address",
+            "accessibility_info",
+            "arrival_instructions",
+            "additional_info",
+            "wc_and_facilities",
+            "www_url",
+            "project",
+            "translations",
+            "occurrences",
+        )
         filter_fields = ("project_id",)
 
     @classmethod


### PR DESCRIPTION
## Description

Fix warnings:
- sentry_sdk deprecation warning by using current scope
- graphene-django warning that DjangoObjectType needs fields/exclude by explicitly defining the fields
- DEFAULT_FILE_STORAGE deprecation warning by using STORAGES instead
  - Needs [DevOps PR #10214](https://dev.azure.com/City-of-Helsinki/kukkuu/_git/kukkuu-pipelines/pullrequest/10214) for this change to work in pipelines
- "The USE_L10N setting is deprecated" deprecation warning by removing it, as the default is the same as the set value
- Remove ChildNode deprecation warnings and document fields' behavior

## Related

- [KK-1357](https://helsinkisolutionoffice.atlassian.net/browse/KK-1357)
- https://github.com/City-of-Helsinki/kukkuu/pull/437 as an approved extra

## Required DevOps pipeline changes
- [DevOps PR #10214](https://dev.azure.com/City-of-Helsinki/kukkuu/_git/kukkuu-pipelines/pullrequest/10214): "KK-1357 | Change DEFAULT_FILE_STORAGE to STORAGES_DEFAULT_BACKEND"

[KK-1357]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ