### PR TITLE
Configure audit logging in Kukkuu project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,5 +28,9 @@ repos:
   - repo: https://github.com/jorisroovers/gitlint
     rev:  v0.19.1
     hooks:
-      -   id: gitlint
-          stages: [commit-msg]
+      - id: gitlint
+        stages: [commit-msg]
+  - repo: https://github.com/thlorenz/doctoc
+    rev: v2.2.0 
+    hooks:
+      - id: doctoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- DOCTOC SKIP -->
 <!-- REMINDER: While updating changelog, also remember to update
 the version in kukkuu/__init.py__ -->
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,33 @@
 
 [![status](https://travis-ci.com/City-of-Helsinki/kukkuu.svg)](https://github.com/City-of-Helsinki/kukkuu)
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Environments](#environments)
+- [Development with Docker](#development-with-docker)
+- [Development without Docker](#development-without-docker)
+  - [Installing Python requirements](#installing-python-requirements)
+  - [Database](#database)
+  - [Notification import](#notification-import)
+  - [Cron jobs](#cron-jobs)
+    - [Reminder notifications](#reminder-notifications)
+    - [Feedback notifications](#feedback-notifications)
+    - [Queued email sending](#queued-email-sending)
+    - [SMS notifications](#sms-notifications)
+  - [Daily running, Debugging](#daily-running-debugging)
+- [Authorization](#authorization)
+- [GDPR API data export](#gdpr-api-data-export)
+- [GraphQL API Documentation](#graphql-api-documentation)
+- [Report API](#report-api)
+- [QR-code ticket verification](#qr-code-ticket-verification)
+- [Keeping Python requirements up to date](#keeping-python-requirements-up-to-date)
+- [Code linting & formatting](#code-linting--formatting)
+  - [Pre-commit hooks](#pre-commit-hooks)
+- [Issues board](#issues-board)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Environments
 
 Production environment:
@@ -192,15 +219,18 @@ Basic `ruff` commands:
 - Format: `ruff format`
 
 Basically:
- - Ruff linter (i.e. `ruff check --fix`) does what `flake8` and `isort` did before.
- - Ruff formatter (i.e. `ruff format`) does what `black` did before.
+
+- Ruff linter (i.e. `ruff check --fix`) does what `flake8` and `isort` did before.
+- Ruff formatter (i.e. `ruff format`) does what `black` did before.
 
 Integrations for `ruff` are available for many editors:
- - https://docs.astral.sh/ruff/integrations/
+
+- https://docs.astral.sh/ruff/integrations/
 
 ### Pre-commit hooks
 
 You can use [`pre-commit`](https://pre-commit.com/) to lint and format your code before committing:
+
 1. Install `pre-commit` (there are many ways to do but let's use pip as an example):
    - `pip install pre-commit`
 2. Set up git hooks from `.pre-commit-config.yaml`, run this command from project root:

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ To use the SMS notification functionality, you have to acquire the API_KEY from 
 
 ## Authorization
 
-The user profiles authenticates themselves in a centralized authentication server of the city of Helsinki. For long it has been [Tunnistamo](https://github.com/City-of-Helsinki/tunnistamo), but in the summer of the year 2024, it should be changed to a Keycloak service of the [Helsinki-Profile](https://github.com/City-of-Helsinki/open-city-profile) service environment.
+The user profiles authenticates themselves in a centralized authentication server of the city of Helsinki. For long it was [Tunnistamo](https://github.com/City-of-Helsinki/tunnistamo), but during autumn 2024, it was changed to a Keycloak service of the [Helsinki-Profile](https://github.com/City-of-Helsinki/open-city-profile) service environment.
 
 The Tunnistamo can be configured to be used [locally](./docs/setup-tunnistamo.md#use-a-local-tunnistamo) or from the [test environment](./docs/setup-tunnistamo.md#use-the-public-test-tunnistamo).
 

--- a/children/admin.py
+++ b/children/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 
 from events.models import Enrolment, TicketSystemPassword
+from hel_django_auditlog_extra.mixins import AuditlogAdminViewAccessLogMixin
 from languages.models import Language
 from subscriptions.models import FreeSpotNotificationSubscription
 
@@ -54,7 +55,10 @@ class TicketSystemPasswordInline(admin.TabularInline):
 
 
 @admin.register(Child)
-class ChildAdmin(admin.ModelAdmin):
+class ChildAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
+    # To write access log to audit log of each instance in the admin list view
+    enable_list_view_audit_logging = True
+
     list_display = (
         "id",
         "name",

--- a/children/schema.py
+++ b/children/schema.py
@@ -23,6 +23,7 @@ from common.schema import (
 from common.utils import login_required, map_enums_to_values_in_kwargs, update_object
 from django_ilmoitin.utils import send_notification
 from events.models import Event, EventGroup, EventQueryset, Occurrence
+from hel_django_auditlog_extra.graphene_decorators import auditlog_access
 from kukkuu.exceptions import (
     ApiUsageError,
     DataValidationError,
@@ -52,6 +53,7 @@ class ChildrenConnection(graphene.Connection):
         return self.length
 
 
+@auditlog_access
 class ChildNotesNode(DjangoObjectType):
     """
     Node for handling child's notes separately from their other data.
@@ -81,6 +83,7 @@ class ChildNotesNode(DjangoObjectType):
             return None
 
 
+@auditlog_access
 class ChildNode(DjangoObjectType):
     available_events = relay.ConnectionField(
         "events.schema.EventConnection",

--- a/children/tests/test_api.py
+++ b/children/tests/test_api.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 import pytest
 import pytz
+from auditlog.context import disable_auditlog
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.utils import timezone
@@ -1477,7 +1478,8 @@ def test_children_pagination_result_set(
     limit = 20  # There should be more than 2 pages.
     offset = (page - 1) * limit
 
-    ChildWithGuardianFactory.create_batch(total_count, project=project)
+    with disable_auditlog():
+        ChildWithGuardianFactory.create_batch(total_count, project=project)
 
     variables = {"projectId": get_global_id(project), "limit": limit, "offset": offset}
     executed = project_user_api_client.execute(
@@ -1562,7 +1564,8 @@ def test_children_pagination_cursor_generation(
     total_count = 100
     offset = (page - 1) * limit
 
-    ChildWithGuardianFactory.create_batch(total_count, project=project)
+    with disable_auditlog():
+        ChildWithGuardianFactory.create_batch(total_count, project=project)
 
     query = """
     query Children($projectId: ID!, $limit: Int, $offset: Int) {

--- a/docs/setup-keycloak.md
+++ b/docs/setup-keycloak.md
@@ -1,3 +1,12 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Setup Keycloak](#setup-keycloak)
+  - [Use the public test Keycloak](#use-the-public-test-keycloak)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Setup Keycloak
 
 ## Use the public test Keycloak

--- a/docs/setup-tunnistamo.md
+++ b/docs/setup-tunnistamo.md
@@ -1,3 +1,13 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Setup Tunnistamo](#setup-tunnistamo)
+  - [Use a local Tunnistamo](#use-a-local-tunnistamo)
+  - [Use the public test Tunnistamo](#use-the-public-test-tunnistamo)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Setup Tunnistamo
 
 ## Use a local Tunnistamo

--- a/events/admin.py
+++ b/events/admin.py
@@ -9,6 +9,7 @@ from parler.admin import TranslatableAdmin
 from parler.forms import TranslatableModelForm
 
 from events.ticket_service import check_ticket_validity
+from hel_django_auditlog_extra.mixins import AuditlogAdminViewAccessLogMixin
 from subscriptions.models import FreeSpotNotificationSubscription
 
 from .models import Enrolment, Event, EventGroup, Occurrence, TicketSystemPassword
@@ -159,7 +160,8 @@ class FreeSpotNotificationSubscriptionInline(admin.TabularInline):
 
 
 @admin.register(Occurrence)
-class OccurrenceAdmin(admin.ModelAdmin):
+class OccurrenceAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
+    enable_list_view_audit_logging = False  # Not needed in list view
     list_display = (
         "time",
         "event",
@@ -339,7 +341,8 @@ class PasswordAssignedListFilter(BaseBooleanListFilter):
 
 
 @admin.register(TicketSystemPassword)
-class TicketSystemChildPasswordAdmin(admin.ModelAdmin):
+class TicketSystemChildPasswordAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
+    enable_list_view_audit_logging = True
     fields = (
         "value",
         "event",
@@ -384,7 +387,8 @@ class TicketSystemChildPasswordAdmin(admin.ModelAdmin):
 
 
 @admin.register(Enrolment)
-class EnrolmentAdmin(admin.ModelAdmin):
+class EnrolmentAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
+    enable_list_view_audit_logging = True
     list_display = (
         "id",
         "child",

--- a/events/schema.py
+++ b/events/schema.py
@@ -35,6 +35,7 @@ from events.exceptions import (
 from events.filters import EventFilter, OccurrenceFilter
 from events.models import Enrolment, Event, EventGroup, Occurrence, TicketSystemPassword
 from events.ticket_service import check_ticket_validity
+from hel_django_auditlog_extra.graphene_decorators import auditlog_access
 from kukkuu.exceptions import (
     ChildAlreadyJoinedEventError,
     DataValidationError,
@@ -567,6 +568,7 @@ class OccurrenceNode(DjangoObjectType):
         )
 
 
+@auditlog_access
 class EnrolmentNode(DjangoObjectType):
     reference_id = graphene.String(description="An unique encoded reference id")
 
@@ -584,6 +586,7 @@ class EnrolmentNode(DjangoObjectType):
         return self.reference_id
 
 
+@auditlog_access
 class ExternalTicketSystemEnrolmentNode(DjangoObjectType):
     created_at = graphene.DateTime(required=True)
 

--- a/gdpr/README.md
+++ b/gdpr/README.md
@@ -1,3 +1,13 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [How to integrate the Culture Kids to Helsinki-Profile GDPR API](#how-to-integrate-the-culture-kids-to-helsinki-profile-gdpr-api)
+- [GDPR API data export](#gdpr-api-data-export)
+- [Kukkuu GDPR API tester](#kukkuu-gdpr-api-tester)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # How to integrate the Culture Kids to Helsinki-Profile GDPR API
 
 As background information and instructions for integrating the service with Helsinki-Profile, see the documentation for [How to integrate to Helsinki-Profile through Tunnistamo](./docs/how-to-integrate-to-Helsinki-profile-with-Tunnistamo.md).

--- a/gdpr/docs/how-to-integrate-to-Helsinki-profile-with-Tunnistamo.md
+++ b/gdpr/docs/how-to-integrate-to-Helsinki-profile-with-Tunnistamo.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Integrate the Culture Kids service to the Helsinki-Profile](#integrate-the-culture-kids-service-to-the-helsinki-profile)
+  - [1. Download and install all the needed services](#1-download-and-install-all-the-needed-services)
+  - [2. Setup the clients and their scopes in Tunnistamo](#2-setup-the-clients-and-their-scopes-in-tunnistamo)
+    - [Communication between the Culture kids apps and the Tunnistamo](#communication-between-the-culture-kids-apps-and-the-tunnistamo)
+    - [Communication between the Helsinki-profile and the Tunnistamo](#communication-between-the-helsinki-profile-and-the-tunnistamo)
+    - [Communication from Helsinki-profile to the Culture Kids through Tunnistamo](#communication-from-helsinki-profile-to-the-culture-kids-through-tunnistamo)
+  - [3. Setup the Helsinki-Profile](#3-setup-the-helsinki-profile)
+  - [4. Test that all the communication works](#4-test-that-all-the-communication-works)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Integrate the Culture Kids service to the Helsinki-Profile
 
 ## 1. Download and install all the needed services

--- a/gdpr/docs/kukkuu-profile-through-tunnistamo.md
+++ b/gdpr/docs/kukkuu-profile-through-tunnistamo.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Culture Kids with Helsinki-Profile GDPR API through Tunnistamo](#culture-kids-with-helsinki-profile-gdpr-api-through-tunnistamo)
+  - [OIDC API scopes](#oidc-api-scopes)
+    - [Kukkuu GDPR Query API Scope Specifier](#kukkuu-gdpr-query-api-scope-specifier)
+    - [Kukkuu GDPR Delete API Scope Specifier](#kukkuu-gdpr-delete-api-scope-specifier)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Culture Kids with Helsinki-Profile GDPR API through Tunnistamo
 
 ## OIDC API scopes

--- a/gdpr/docs/setup-helsinki-profile.md
+++ b/gdpr/docs/setup-helsinki-profile.md
@@ -1,3 +1,13 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Setup the Helsinki-Profile for internal use and for UI](#setup-the-helsinki-profile-for-internal-use-and-for-ui)
+  - [Configure the internal service (for Helsinki-Profile-UI and internal Graphql-UI)](#configure-the-internal-service-for-helsinki-profile-ui-and-internal-graphql-ui)
+  - [Configure the Culture kids service](#configure-the-culture-kids-service)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Setup the Helsinki-Profile for internal use and for UI
 
 In order to get the Helsinki-Profile UI to work with API, The Helsinki-Profile services needs to be set so that they match with the Tunnistamo client ids. Also, the Helsinki-Profile API itself needs an internal service.

--- a/gdpr/docs/tunnistamo-kukkuu-configuration.md
+++ b/gdpr/docs/tunnistamo-kukkuu-configuration.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Culture Kids with Tunnistamo](#culture-kids-with-tunnistamo)
+  - [OIDC provider clients](#oidc-provider-clients)
+    - [Kukkuu API](#kukkuu-api)
+    - [Kukkuu UI](#kukkuu-ui)
+    - [Kukkuu Admin UI](#kukkuu-admin-ui)
+  - [OIDC API](#oidc-api)
+    - [Kukkuu API](#kukkuu-api-1)
+  - [OIDC API scopes](#oidc-api-scopes)
+    - [Kukkuu API Scope](#kukkuu-api-scope)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Culture Kids with Tunnistamo
 
 ## OIDC provider clients

--- a/gdpr/docs/tunnistamo-profile-configuration.md
+++ b/gdpr/docs/tunnistamo-profile-configuration.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Helsinki-Profile with Tunnistamo](#helsinki-profile-with-tunnistamo)
+  - [OIDC provider clients](#oidc-provider-clients)
+    - [Helsinki-Profile API](#helsinki-profile-api)
+    - [Helsinki-Profile UI](#helsinki-profile-ui)
+  - [OIDC API](#oidc-api)
+    - [Helsinki-profile API](#helsinki-profile-api)
+  - [OIDC API scopes](#oidc-api-scopes)
+    - [Helsinki-profile API Scope](#helsinki-profile-api-scope)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Helsinki-Profile with Tunnistamo
 
 ## OIDC provider clients

--- a/hel_django_auditlog_extra/README.md
+++ b/hel_django_auditlog_extra/README.md
@@ -264,12 +264,12 @@ Code reference: [mixins.py](./mixins.py).
 
     By default, only access to individual object views (change, history, delete)
     is logged. To enable logging for the list view, set the
-    `write_accessed_from_list_view` attribute to `True` in your `ModelAdmin`.
+    `enable_list_view_audit_logging` attribute to `True` in your `ModelAdmin`.
     Please note that this will trigger a very intensive logging and a lots of
     access log data will be created and stored!
 
     Attributes:
-    write_accessed_from_list_view (bool):
+    enable_list_view_audit_logging (bool):
     A flag to enable/disable logging access from the list view.
     Defaults to `False`.
 
@@ -282,7 +282,7 @@ from .models import MyModel
 
 @admin.register(MyModel)
 class MyModelAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
-    write_accessed_from_list_view = True  # Enable list view logging
+    enable_list_view_audit_logging = True  # Enable list view logging
     # ... other admin configurations ...
 ```
 
@@ -369,22 +369,22 @@ AuditLogConfigurationHelper.raise_error_if_unconfigured_models()
           AuditLogConfigurationHelper.raise_error_if_unconfigured_models()
   ```
 
-  Remember that signals and receivers needs to be connected (for example in `apps.py`):
+  Remember that signals (and receivers) needs to be registered to Django after all the models are registered (for example in `apps.py`):
 
   ```python
   from django.apps import AppConfig
-  from django.core.signals import request_finished
-
 
   class MyAppConfig(AppConfig):
       ...
 
       def ready(self):
-          # Implicitly connect signal handlers decorated with @receiver.
-          from . import signals
-
-          # Explicitly connect a signal handler.
-          request_finished.connect(signals.my_callback)
+            # Implicitly connect signal handlers decorated with @receiver.
+            from . import signals
+            
+            # OR
+            # Explicitly connect a signal handler.
+            # from django.core.signals import post_migrate
+            # post_migrate.connect(signals.check_audit_log_configuration)
   ```
 
   Reference: https://docs.djangoproject.com/en/5.1/topics/signals/#listening-to-signals.

--- a/hel_django_auditlog_extra/mixins.py
+++ b/hel_django_auditlog_extra/mixins.py
@@ -16,12 +16,12 @@ class AuditlogAdminViewAccessLogMixin:
 
     By default, only access to individual object views (change, history, delete)
     is logged. To enable logging for the list view, set the
-    `write_accessed_from_list_view` attribute to `True` in your `ModelAdmin`.
+    `enable_list_view_audit_logging` attribute to `True` in your `ModelAdmin`.
     Please note that this will trigger a very intensive logging and a lots of
     access log data will be created and stored!
 
     Attributes:
-        write_accessed_from_list_view (bool):
+        enable_list_view_audit_logging (bool):
             A flag to enable/disable logging access from the list view.
             Defaults to `False`.
 
@@ -34,18 +34,18 @@ class AuditlogAdminViewAccessLogMixin:
 
         @admin.register(MyModel)
         class MyModelAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
-            write_accessed_from_list_view = True  # Enable list view logging
+            enable_list_view_audit_logging = True  # Enable list view logging
             # ... other admin configurations ...
         ```
     """
 
-    # To write audit log of each instance in the admin view
-    write_accessed_from_list_view = False
+    # To write access log to audit log of each instance in the admin list view
+    enable_list_view_audit_logging = False
 
     def changelist_view(self, request, extra_context=None):
         """
         Handles the changelist view (list view) and logs access events for
-        objects on the current page if `write_accessed_from_list_view` is `True`.
+        objects on the current page if `enable_list_view_audit_logging` is `True`.
 
         The changelist in the response's context_data (i.e. "cl") should be set by the
         super().changelist_view call, see e.g.
@@ -59,7 +59,7 @@ class AuditlogAdminViewAccessLogMixin:
             The response from the superclass's `changelist_view` method.
         """
         response = super().changelist_view(request, extra_context)
-        if self.write_accessed_from_list_view:
+        if self.enable_list_view_audit_logging:
             changelist = response.context_data["cl"]
             for obj in changelist.result_list:
                 accessed.send(sender=obj.__class__, instance=obj, actor=request.user)

--- a/hel_django_auditlog_extra/tests/test_mixins.py
+++ b/hel_django_auditlog_extra/tests/test_mixins.py
@@ -115,7 +115,7 @@ def model_admin(all_objects):
             Django admin views.
             """
 
-            write_accessed_from_list_view = False
+            enable_list_view_audit_logging = False
 
             def get_changelist(self, request, **kwargs):
                 return MockedChangeList
@@ -149,7 +149,7 @@ def test_changelist_view_logging(
     factory, user, model_admin, is_write_accessed_enabled, all_objects
 ):
     auditlog_count_on_start = LogEntry.objects.count()
-    model_admin.write_accessed_from_list_view = is_write_accessed_enabled
+    model_admin.enable_list_view_audit_logging = is_write_accessed_enabled
     request = factory.get("/admin/hel_django_auditlog_extra/dummytestmodel/")
     request.user = user
     with set_actor(request.user, remote_addr=REMOTE_ADDR):

--- a/kukkuu/apps.py
+++ b/kukkuu/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class KukkuuProjectConfig(AppConfig):
+    name = "kukkuu"
+
+    def ready(self):
+        from hel_django_auditlog_extra.utils import AuditLogConfigurationHelper
+
+        AuditLogConfigurationHelper.raise_error_if_unconfigured_models()

--- a/kukkuu/auditlog_settings.py
+++ b/kukkuu/auditlog_settings.py
@@ -1,0 +1,89 @@
+# Register all models by default
+AUDITLOG_INCLUDE_ALL_MODELS = True
+
+# Exclude the IP address from logging.
+# When using “AuditlogMiddleware”, the IP address is logged by default
+AUDITLOG_DISABLE_REMOTE_ADDR = False
+
+# Disables logging during raw save. (I.e. for instance using loaddata)
+# M2M operations will still be logged, since they’re never considered raw.
+AUDITLOG_DISABLE_ON_RAW_SAVE = True
+
+# Exclude models in registration process.
+# It will be considered when AUDITLOG_INCLUDE_ALL_MODELS is True.
+AUDITLOG_EXCLUDE_TRACKING_MODELS = (
+    "admin.logentry",  # excluded by default
+    "auditlog.logentry",  # excluded by default
+    "contenttypes.contenttype",
+    "sessions.session",
+    "helusers.oidcbackchannellogoutevent",
+    "mailer.dontsendentry",
+    "django_ilmoitin.notificationtemplatetranslation",
+    "projects.projecttranslation",
+    "events.eventtranslation",
+    "events.eventgrouptranslation",
+    "venues.venuetranslation",
+    "languages.languagetranslation",
+    "messaging.messagetranslation",
+    "users.guardian_languages_spoken_at_home",
+    "children.child_languages_spoken_at_home",
+    "messaging.message_occurrences",
+    "django_ilmoitin.notificationtemplate_admins_to_notify",
+    "mailer.message",
+    "mailer.messagelog",
+    "languages.language",
+)
+
+# Configure models registration and other behaviours.
+AUDITLOG_INCLUDE_TRACKING_MODELS = (
+    "users.user_user_permissions",
+    "users.user_groups",
+    "users.user_ad_groups",
+    "auth.group_permissions",
+    "helusers.adgroup",
+    "helusers.adgroupmapping",
+    "auth.permission",
+    "auth.group",
+    "django_ilmoitin.notificationtemplate",
+    "guardian.groupobjectpermission",
+    "guardian.userobjectpermission",
+    {
+        "model": "users.user",
+        "exclude_fields": [
+            "last_login",
+        ],
+        "mask_fields": [
+            "first_name",
+            "last_name",
+            "email",
+        ],
+        "serialize_data": True,
+        "serialize_auditlog_fields_only": False,
+    },
+    {
+        "model": "users.guardian",
+        "mask_fields": ["first_name", "last_name", "email", "phone_number"],
+        "serialize_data": True,
+        "serialize_auditlog_fields_only": False,
+    },
+    {
+        "model": "children.child",
+        "mask_fields": [
+            "name",
+        ],
+        "serialize_data": True,
+        "serialize_auditlog_fields_only": False,
+    },
+    "children.relationship",
+    "projects.project",
+    "events.event",
+    "events.occurrence",
+    "events.enrolment",
+    "events.eventgroup",
+    "events.ticketsystempassword",
+    "venues.venue",
+    "subscriptions.freespotnotificationsubscription",
+    "messaging.message",
+    "reports.permission",
+    "verification_tokens.verificationtoken",
+)

--- a/kukkuu/auditlog_settings.py
+++ b/kukkuu/auditlog_settings.py
@@ -14,24 +14,10 @@ AUDITLOG_DISABLE_ON_RAW_SAVE = True
 AUDITLOG_EXCLUDE_TRACKING_MODELS = (
     "admin.logentry",  # excluded by default
     "auditlog.logentry",  # excluded by default
-    "contenttypes.contenttype",
-    "sessions.session",
-    "helusers.oidcbackchannellogoutevent",
-    "mailer.dontsendentry",
-    "django_ilmoitin.notificationtemplatetranslation",
-    "projects.projecttranslation",
-    "events.eventtranslation",
-    "events.eventgrouptranslation",
-    "venues.venuetranslation",
-    "languages.languagetranslation",
-    "messaging.messagetranslation",
-    "users.guardian_languages_spoken_at_home",
-    "children.child_languages_spoken_at_home",
-    "messaging.message_occurrences",
-    "django_ilmoitin.notificationtemplate_admins_to_notify",
-    "mailer.message",
-    "mailer.messagelog",
-    "languages.language",
+    "contenttypes.contenttype",  # system model
+    "sessions.session",  # auth model
+    "helusers.oidcbackchannellogoutevent",  # auth model
+    "languages.language",  # system
 )
 
 # Configure models registration and other behaviours.
@@ -45,34 +31,23 @@ AUDITLOG_INCLUDE_TRACKING_MODELS = (
     "auth.permission",
     "auth.group",
     "django_ilmoitin.notificationtemplate",
+    "django_ilmoitin.notificationtemplate_admins_to_notify",
     "guardian.groupobjectpermission",
     "guardian.userobjectpermission",
     {
         "model": "users.user",
         "exclude_fields": [
-            "last_login",
-        ],
-        "mask_fields": [
-            "first_name",
-            "last_name",
-            "email",
+            "last_login",  # don't write log of every request
         ],
         "serialize_data": True,
-        "serialize_auditlog_fields_only": False,
     },
     {
         "model": "users.guardian",
-        "mask_fields": ["first_name", "last_name", "email", "phone_number"],
         "serialize_data": True,
-        "serialize_auditlog_fields_only": False,
     },
     {
         "model": "children.child",
-        "mask_fields": [
-            "name",
-        ],
         "serialize_data": True,
-        "serialize_auditlog_fields_only": False,
     },
     "children.relationship",
     "projects.project",
@@ -86,4 +61,18 @@ AUDITLOG_INCLUDE_TRACKING_MODELS = (
     "messaging.message",
     "reports.permission",
     "verification_tokens.verificationtoken",
+    # secondary
+    "django_ilmoitin.notificationtemplatetranslation",
+    "projects.projecttranslation",
+    "events.eventtranslation",
+    "events.eventgrouptranslation",
+    "venues.venuetranslation",
+    "languages.languagetranslation",
+    "messaging.messagetranslation",
+    "messaging.message_occurrences",
+    "users.guardian_languages_spoken_at_home",
+    "children.child_languages_spoken_at_home",
+    "mailer.dontsendentry",
+    "mailer.message",
+    "mailer.messagelog",
 )

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -224,6 +224,8 @@ INSTALLED_APPS = [
     "importers",
     "reports",
     "verification_tokens",
+    "hel_django_auditlog_extra.apps.HelDjangoAuditLogExtraConfig",
+    "kukkuu",
     "django_cleanup.apps.CleanupConfig",  # This must be included last
 ]
 
@@ -237,7 +239,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "auditlog.middleware.AuditlogMiddleware",
+    "hel_django_auditlog_extra.middleware.AuditlogMiddleware",
 ]
 
 TEMPLATES = [
@@ -324,7 +326,9 @@ PARLER_ENABLE_CACHING = False
 
 GRAPHENE = {
     "SCHEMA": "kukkuu.schema.schema",
-    "MIDDLEWARE": ["graphql_jwt.middleware.JSONWebTokenMiddleware"],
+    "MIDDLEWARE": [
+        "graphql_jwt.middleware.JSONWebTokenMiddleware",
+    ],
 }
 
 GRAPHQL_JWT = {"JWT_AUTH_HEADER_PREFIX": "Bearer"}
@@ -407,6 +411,9 @@ HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED = env("HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED
 APP_RELEASE = env("APP_RELEASE")
 # get build time from a file in docker image
 APP_BUILD_TIME = datetime.fromtimestamp(os.path.getmtime(__file__))
+
+# Load auditlog settings
+from kukkuu.auditlog_settings import *  # noqa: E402, F403
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.

--- a/kukkuu_mailer_admin/admin.py
+++ b/kukkuu_mailer_admin/admin.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
-from mailer.admin import MessageLogAdmin, show_to
-from mailer.models import MessageLog, RESULT_CODES
+from mailer.admin import MessageAdmin, MessageLogAdmin, show_to
+from mailer.models import Message, MessageLog, RESULT_CODES
+
+from hel_django_auditlog_extra.mixins import AuditlogAdminViewAccessLogMixin
 
 
 def custom_titled_filter(title: str):
@@ -36,9 +38,10 @@ def sent_to_mail_server(message: MessageLog) -> str:
 sent_to_mail_server.short_description = _("Sent to mail server")
 
 
-class KukkuuMessageLogAdmin(MessageLogAdmin):
+class KukkuuMessageLogAdmin(AuditlogAdminViewAccessLogMixin, MessageLogAdmin):
     """Override the MessageLogAdmin provided by django_mailer."""
 
+    enable_list_view_audit_logging = True
     list_display = [
         "id",
         show_to,
@@ -54,3 +57,15 @@ class KukkuuMessageLogAdmin(MessageLogAdmin):
 admin.site.unregister(MessageLog)
 # Register a new admin for the MessageLog.
 admin.site.register(MessageLog, KukkuuMessageLogAdmin)
+
+
+class KukkuuMessageAdmin(AuditlogAdminViewAccessLogMixin, MessageAdmin):
+    """Override the MessageAdmin provided by django_mailer."""
+
+    enable_list_view_audit_logging = True
+
+
+# Unregister the Message admin provided by the `django_mailer`.
+admin.site.unregister(Message)
+# Register a new admin for the Message.
+admin.site.register(Message, KukkuuMessageAdmin)

--- a/messaging/admin.py
+++ b/messaging/admin.py
@@ -4,13 +4,15 @@ from django.db.models import Count
 from django.utils.translation import gettext_lazy as _
 from parler.admin import TranslatableAdmin
 
+from hel_django_auditlog_extra.mixins import AuditlogAdminViewAccessLogMixin
 from messaging.exceptions import AlreadySentError
 
 from .models import Message
 
 
 @admin.register(Message)
-class MessageAdmin(TranslatableAdmin):
+class MessageAdmin(AuditlogAdminViewAccessLogMixin, TranslatableAdmin):
+    enable_list_view_audit_logging = True
     list_display = (
         "id",
         "get_subject_with_fallback",

--- a/messaging/schema.py
+++ b/messaging/schema.py
@@ -19,6 +19,7 @@ from common.utils import (
     update_object_with_translations,
 )
 from events.models import Event, Occurrence
+from hel_django_auditlog_extra.graphene_decorators import auditlog_access
 from kukkuu.exceptions import DataValidationError, MessageAlreadySentError
 from projects.models import Project
 from users.models import User
@@ -122,6 +123,7 @@ class MessageFilter(django_filters.FilterSet):
         return {**data, "occurrences": occurrences_ids}
 
 
+@auditlog_access
 class MessageNode(DjangoObjectType):
     subject = graphene.String()
     body_text = graphene.String()

--- a/subscriptions/README.md
+++ b/subscriptions/README.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Subscriptions app](#subscriptions-app)
+  - [Free spot notifications](#free-spot-notifications)
+    - [Authenticated users](#authenticated-users)
+    - [Authorization with a token](#authorization-with-a-token)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ### Subscriptions app
 
 #### Free spot notifications

--- a/subscriptions/schema.py
+++ b/subscriptions/schema.py
@@ -14,6 +14,7 @@ from common.utils import (
 )
 from events.models import Occurrence
 from events.schema import OccurrenceNode
+from hel_django_auditlog_extra.graphene_decorators import auditlog_access
 from kukkuu.consts import OCCURRENCE_IS_NOT_FULL_ERROR
 from kukkuu.exceptions import (
     AlreadySubscribedError,
@@ -27,6 +28,7 @@ from verification_tokens.decorators import user_from_auth_verification_token
 logger = logging.getLogger(__name__)
 
 
+@auditlog_access
 class FreeSpotNotificationSubscriptionNode(DjangoObjectType):
     occurrence = graphene.Field(OccurrenceNode)  # WORKAROUND: See resolve_occurrence
 

--- a/users/README.md
+++ b/users/README.md
@@ -1,3 +1,20 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Users app](#users-app)
+  - [Models](#models)
+    - [User](#user)
+    - [Guardian](#guardian)
+  - [GraphQL Schema](#graphql-schema)
+    - [Guardians](#guardians)
+    - [My profile](#my-profile)
+      - [Update the email](#update-the-email)
+      - [Manage communication subscriptions](#manage-communication-subscriptions)
+    - [My admin profile](#my-admin-profile)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ### Users app
 
 #### Models

--- a/users/admin.py
+++ b/users/admin.py
@@ -16,6 +16,7 @@ from guardian.admin import GuardedModelAdmin
 from children.models import Relationship
 from django_ilmoitin.models import NotificationTemplate
 from django_ilmoitin.utils import render_notification_template
+from hel_django_auditlog_extra.mixins import AuditlogAdminViewAccessLogMixin
 from languages.models import Language
 from projects.models import Project
 from reports.models import Permission as ReportPermission
@@ -198,7 +199,8 @@ def obsolete_and_send_user_auth_service_is_changing_notification(
 
 
 @admin.register(Guardian)
-class GuardianAdmin(admin.ModelAdmin):
+class GuardianAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
+    enable_list_view_audit_logging = True
     list_display = (
         "id",
         "user_link",
@@ -269,7 +271,13 @@ def make_obsoleted(modeladmin, request, queryset):
 
 
 @admin.register(get_user_model())
-class UserAdmin(PermissionFilterMixin, GuardedModelAdmin, DjangoUserAdmin):
+class UserAdmin(
+    AuditlogAdminViewAccessLogMixin,
+    PermissionFilterMixin,
+    GuardedModelAdmin,
+    DjangoUserAdmin,
+):
+    enable_list_view_audit_logging = True
     list_display = (
         "username",
         "id",
@@ -320,7 +328,10 @@ class UserInline(admin.StackedInline):
 
 
 @admin.register(Group)
-class GroupAdmin(PermissionFilterMixin, DjangoGroupAdmin):
+class GroupAdmin(
+    AuditlogAdminViewAccessLogMixin, PermissionFilterMixin, DjangoGroupAdmin
+):
+    enable_list_view_audit_logging = False  # not needed in list view
     list_display = ("name", "get_user_count")
     inlines = (UserInline,)
 

--- a/users/schema.py
+++ b/users/schema.py
@@ -7,6 +7,7 @@ from graphene_django.types import DjangoObjectType
 
 from common.schema import LanguageEnum, set_obj_languages_spoken_at_home
 from common.utils import login_required, map_enums_to_values_in_kwargs, update_object
+from hel_django_auditlog_extra.graphene_decorators import auditlog_access
 from kukkuu.exceptions import ObjectDoesNotExistError
 from projects.schema import ProjectNode
 from verification_tokens.decorators import user_from_auth_verification_token
@@ -22,6 +23,7 @@ from .utils import (
 User = get_user_model()
 
 
+@auditlog_access
 class GuardianNode(DjangoObjectType):
     language = LanguageEnum(required=True)
 
@@ -70,6 +72,7 @@ class GuardianCommunicationSubscriptionsNode(DjangoObjectType):
         return queryset.user_can_view(info.context.user)
 
 
+@auditlog_access
 class AdminNode(DjangoObjectType):
     projects = DjangoConnectionField(ProjectNode)
 

--- a/verification_tokens/admin.py
+++ b/verification_tokens/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 
+from hel_django_auditlog_extra.mixins import AuditlogAdminViewAccessLogMixin
+
 from .models import VerificationToken
 
 
@@ -13,7 +15,8 @@ verification_token_user_full_name.short_description = "Name"
 
 
 @admin.register(VerificationToken)
-class VerificationTokenAdmin(admin.ModelAdmin):
+class VerificationTokenAdmin(AuditlogAdminViewAccessLogMixin, admin.ModelAdmin):
+    enable_list_view_audit_logging = True
     list_display = (
         "key",
         "verification_type",


### PR DESCRIPTION
Bases on https://github.com/City-of-Helsinki/kukkuu/pull/440.

KK-1113.

- Configure the django-auditlog and the hel_django_auditlog_extra.
- Add `auditlog_access` -decorator to the DjangoObjectNodes in Graphene that are not publicly available (and contains any personal information).
- Add admin log mixin to Django admin site to the models that are not publicly avaialble through the API.
- Use audit log configuration helper.