### PR TITLE
Improve the readiness and liveness probes

### DIFF
--- a/custom_health_checks/README.md
+++ b/custom_health_checks/README.md
@@ -1,0 +1,61 @@
+# Custom health checks
+
+## Table of Contents
+<!-- TOC start (generated with https://github.com/derlin/bitdowntoc) -->
+
+- [Requirements](#requirements)
+- [What it does](#what-it-does)
+- [Installation](#installation)
+
+<!-- TOC end -->
+
+## Requirements
+
+- [django-health-check](https://pypi.org/project/django-health-check/)
+
+## What it does
+
+In [backends.py](backends.py) there are custom health checks for backend, like database health check, that checks whether the connection to the database is OK.
+
+## Installation
+
+1. Install the requirements
+
+   ```python
+   INSTALLED_APPS = [
+       'health_check', # requirement
+       "custom_health_checks", # this app
+   ]
+   ```
+
+2. Register the custom health check to the `health_check` from [apps.py](apps.py)
+
+   ```python
+   class CustomHealthChecksAppConfig(AppConfig):
+   name = 'custom_health_checks'
+
+   def ready(self):
+       from .backends import DatabaseHealthCheck
+       plugin_dir.register(DatabaseHealthCheck)
+   ```
+
+3. Map the `health_check.urls` in the project's `urls.py`.
+
+   If you want to have the default `health_check` view, map it like this:
+
+   ```python
+   urlpatterns = [
+       # ...
+       path("healthz/", include('health_check.urls'))
+   ]
+   ```
+
+   If you want to have a custom, e.g. a JSON only view, map it like this:
+
+   ```python
+   import views
+   urlpatterns = [
+       # ...
+       path(r'healthz', views.HealthCheckCustomView.as_view(), name='healthz'),
+   ]
+   ```

--- a/custom_health_checks/apps.py
+++ b/custom_health_checks/apps.py
@@ -1,0 +1,16 @@
+import logging
+
+from django.apps import AppConfig
+from health_check.plugins import plugin_dir
+
+logger = logging.getLogger(__name__)
+
+
+class CustomHealthChecksAppConfig(AppConfig):
+    name = "custom_health_checks"
+
+    def ready(self):
+        from .backends import DatabaseHealthCheck
+
+        plugin_dir.register(DatabaseHealthCheck)
+        logger.info("Registered DatabaseHealthCheck to health_check plugins.")

--- a/custom_health_checks/backends.py
+++ b/custom_health_checks/backends.py
@@ -1,0 +1,24 @@
+from django.db import connection
+from health_check.backends import BaseHealthCheckBackend
+from health_check.exceptions import ServiceUnavailable
+
+
+class DatabaseHealthCheck(BaseHealthCheckBackend):
+    """
+    Custom health check for the database connection.
+    """
+
+    critical_service = True
+
+    def check_status(self):
+        """
+        Checks the database connection by executing a simple query.
+        """
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1 FROM users_user LIMIT 1")
+        except Exception as e:
+            raise ServiceUnavailable(f"Database connection failed: {e}")
+
+    def identifier(self):
+        return self.__class__.__name__  # Display name on the endpoint.

--- a/custom_health_checks/tests/test_backends.py
+++ b/custom_health_checks/tests/test_backends.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+import pytest
+from django.db import OperationalError
+from health_check.exceptions import ServiceUnavailable
+
+from custom_health_checks.backends import DatabaseHealthCheck
+
+
+@patch("django.db.connection.cursor")
+def test_database_check_status_success(mock_cursor):
+    """
+    Test that check_status passes when the database connection is successful.
+    """
+    mock_cursor.return_value.__enter__.return_value.execute.return_value = True
+    health_check = DatabaseHealthCheck()
+    health_check.check_status()  # Should not raise an exception
+
+
+@patch("django.db.connection.cursor")
+def test_database_check_status_failure(mock_cursor):
+    """
+    Test that check_status raises ServiceUnavailable when the database
+    connection fails.
+    """
+    mock_cursor.return_value.__enter__.return_value.execute.side_effect = (
+        OperationalError("Database error")
+    )
+    health_check = DatabaseHealthCheck()
+    with pytest.raises(ServiceUnavailable) as exc_info:
+        health_check.check_status()
+    assert "Database connection failed:" in str(exc_info.value)
+
+
+def test_database_check_status_with_real_database(db):  # Use the 'db' fixture
+    """
+    Test check_status with the actual database connection.
+    This assumes your test database is set up correctly.
+    """
+    try:
+        health_check = DatabaseHealthCheck()
+        health_check.check_status()  # Should not raise an exception
+    except ServiceUnavailable as e:
+        pytest.fail(f"Database health check failed: {e}")

--- a/custom_health_checks/tests/test_healthz.py
+++ b/custom_health_checks/tests/test_healthz.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from django.test import Client
+from django.urls import reverse
+from health_check.exceptions import ServiceUnavailable
+
+
+@patch("custom_health_checks.backends.DatabaseHealthCheck.check_status")
+def test_healthz_success(mock_check_status, client: Client):  # Use the 'client' fixture
+    """
+    Test /healthz endpoint with successful health checks.
+    """
+    mock_check_status.return_value = None  # Simulate successful check
+    url = reverse("healthz")
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response.content == b'{"DatabaseHealthCheck": "working"}'
+
+
+@patch("custom_health_checks.backends.DatabaseHealthCheck.check_status")
+def test_healthz_database_error(mock_check_status, client: Client):
+    """
+    Test /healthz endpoint with a database error.
+    """
+    mock_check_status.side_effect = ServiceUnavailable("Database error")
+    url = reverse("healthz")
+    response = client.get(url)
+    assert response.status_code == 500
+    assert b"Database error" in response.content

--- a/custom_health_checks/views.py
+++ b/custom_health_checks/views.py
@@ -1,0 +1,33 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
+from health_check.views import MainView
+
+
+class HealthCheckJSONView(MainView):
+    """
+    The original `health_check` view uses format-attribute or headers to determine
+    what response type is used. The HealthCheckJSONView can be used to ensure
+    that a JSON Response is always used (for health check reporting).
+
+    To apply it, in project's `urls.py`, add the custom JSON view in use like this:
+    >>> # doctest: +SKIP
+    ... import views
+    ...
+    ... urlpatterns = [
+    ...     # ...
+    ...     path(
+    ...         r"healthz",
+    ...         views.HealthCheckCustomView.as_view(),
+    ...         name="health_check_custom",
+    ...     ),
+    ... ]
+    """
+
+    @method_decorator(never_cache)
+    def get(self, request, *args, **kwargs):
+        subset = kwargs.get("subset", None)
+        health_check_has_error = self.check(subset)
+        status_code = 500 if health_check_has_error else 200
+        return self.render_to_response_json(
+            self.filter_plugins(subset=subset), status_code
+        )

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -206,7 +206,9 @@ INSTALLED_APPS = [
     "guardian",
     "rest_framework",
     "drf_spectacular",
+    "health_check",  # requirement
     # local apps
+    "custom_health_checks",
     "users",
     "children",
     "utils",

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from datetime import datetime
 
 import environ
 import sentry_sdk
@@ -88,6 +89,7 @@ env = environ.Env(
     BROWSER_TEST_GROUP_NAME=(str, "Browser test"),
     BROWSER_TEST_AD_GROUP_NAME=(str, "kukkuu_browser_test"),
     KUKKUU_DEFAULT_LOGGING_LEVEL=(str, "INFO"),
+    APP_RELEASE=(str, ""),
 )
 
 if os.path.exists(env_file):
@@ -398,6 +400,11 @@ GDPR_API_USER_PROVIDER = "gdpr.service.get_user"
 GDPR_API_DELETER = "gdpr.service.clear_data"
 
 HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED = env("HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED")
+
+# release information
+APP_RELEASE = env("APP_RELEASE")
+# get build time from a file in docker image
+APP_BUILD_TIME = datetime.fromtimestamp(os.path.getmtime(__file__))
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.

--- a/kukkuu/urls.py
+++ b/kukkuu/urls.py
@@ -9,6 +9,7 @@ from helusers.admin_site import admin
 from rest_framework import routers
 
 from common.utils import get_api_version
+from custom_health_checks.views import HealthCheckJSONView
 from kukkuu.views import SentryGraphQLView
 from reports.api import ChildViewSet, EventGroupViewSet, EventViewSet, VenueViewSet
 
@@ -47,14 +48,15 @@ urlpatterns = [
 #
 # Kubernetes liveness & readiness probes
 #
-def healthz(*args, **kwargs):
-    return HttpResponse(status=200)
 
 
 def readiness(*args, **kwargs):
     return HttpResponse(status=200)
 
 
-urlpatterns += [path("healthz", healthz), path("readiness", readiness)]
+urlpatterns += [
+    path(r"healthz", HealthCheckJSONView.as_view(), name="healthz"),
+    path("readiness", readiness),
+]
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/kukkuu/urls.py
+++ b/kukkuu/urls.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.conf.urls.static import static
-from django.http import HttpResponse
+from django.http import JsonResponse
 from django.urls import include, path, re_path
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -10,6 +10,7 @@ from rest_framework import routers
 
 from common.utils import get_api_version
 from custom_health_checks.views import HealthCheckJSONView
+from kukkuu import __version__
 from kukkuu.views import SentryGraphQLView
 from reports.api import ChildViewSet, EventGroupViewSet, EventViewSet, VenueViewSet
 
@@ -51,7 +52,14 @@ urlpatterns = [
 
 
 def readiness(*args, **kwargs):
-    return HttpResponse(status=200)
+    response_json = {
+        "status": "ok",
+        "release": settings.APP_RELEASE,
+        "packageVersion": __version__,
+        "commitHash": settings.REVISION,
+        "buildTime": settings.APP_BUILD_TIME.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+    }
+    return JsonResponse(response_json, status=200)
 
 
 urlpatterns += [

--- a/requirements.in
+++ b/requirements.in
@@ -24,3 +24,4 @@ hashids
 qrcode
 helsinki-profile-gdpr-api
 markdown
+django-health-check

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ django==4.2.16
     #   django-filter
     #   django-graphql-jwt
     #   django-guardian
+    #   django-health-check
     #   django-helusers
     #   django-ilmoitin
     #   django-mailer
@@ -68,6 +69,8 @@ django-filter==24.3
 django-graphql-jwt==0.4.0
     # via -r requirements.in
 django-guardian==2.4.0
+    # via -r requirements.in
+django-health-check==3.18.3
     # via -r requirements.in
 django-helusers==0.13.0
     # via


### PR DESCRIPTION
KK-1334.

Copy the `custom_health_checks` implementation from the Notification
Service. With that, check that the connection from app to the database
is healthy.

Reference:https://github.com/City-of-Helsinki/notification-service-api/tree/master/custom_health_checks.

<img width="332" alt="image" src="https://github.com/user-attachments/assets/12dd9e45-2689-4c1b-b1f8-885edd1d0924">


The development team has decided that the readiness probe should
response with some refined server release and build information. Copied
the readiness probe implementation from Notification Service to make the
Kukkuu consistent with other apps.

Reference:
https://github.com/City-of-Helsinki/notification-service-api/blob/master/notification_service/urls.py.

<img width="346" alt="image" src="https://github.com/user-attachments/assets/8af21ccb-f0b3-4a69-9205-2057c65fbf24">


