### PR TITLE
chore(docker): consistent name for docker target

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     django:
         build:
             context: .
-            target: ${TARGET:-development}
+            target: ${DOCKER_TARGET:-development}
         env_file:
             - docker-compose.env.yaml
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
             - .:/app
         ports:
             - 8081:8081
+            - 8000:8000
         depends_on:
             - postgres
         container_name: kukkuu-backend


### PR DESCRIPTION
KK-1367.

Usage example: `DOCKER_TARGET=production podman compose up --build`.