### PR TITLE
fix: update projects to db using migrations and management commands

### DIFF
--- a/children/tests/snapshots/snap_test_api.py
+++ b/children/tests/snapshots/snap_test_api.py
@@ -4,211 +4,191 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
-snapshots["test_active_internal_and_ticketmaster_enrolments 1"] = {
-    "data": {
-        "child": {
-            "activeInternalAndTicketSystemEnrolments": {
-                "edges": [
+snapshots['test_active_internal_and_ticketmaster_enrolments 1'] = {
+    'data': {
+        'child': {
+            'activeInternalAndTicketSystemEnrolments': {
+                'edges': [
                     {
-                        "node": {
-                            "__typename": "TicketmasterEnrolmentNode",
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "event": {"name": "1/5"},
+                        'node': {
+                            '__typename': 'TicketmasterEnrolmentNode',
+                            'createdAt': '2020-12-12T00:00:00+00:00',
+                            'event': {
+                                'name': '1/5'
+                            }
                         }
                     },
                     {
-                        "node": {
-                            "__typename": "EnrolmentNode",
-                            "occurrence": {"event": {"name": "2/5"}},
-                        }
-                    },
-                    {
-                        "node": {
-                            "__typename": "TicketmasterEnrolmentNode",
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "event": {"name": "3/5"},
-                        }
-                    },
-                    {
-                        "node": {
-                            "__typename": "EnrolmentNode",
-                            "occurrence": {"event": {"name": "4/5"}},
-                        }
-                    },
-                    {
-                        "node": {
-                            "__typename": "TicketmasterEnrolmentNode",
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "event": {"name": "5/5"},
-                        }
-                    },
-                ]
-            }
-        }
-    }
-}
-
-snapshots["test_add_child_mutation 1"] = {
-    "data": {
-        "addChild": {
-            "child": {"birthyear": 2020, "name": "Pekka", "postalCode": "00820"}
-        }
-    }
-}
-
-snapshots["test_available_events_and_event_groups 1"] = {
-    "data": {
-        "child": {
-            "availableEventsAndEventGroups": {
-                "edges": [
-                    {
-                        "node": {
-                            "__typename": "EventGroupNode",
-                            "name": "this should be the first",
-                        }
-                    },
-                    {
-                        "node": {
-                            "__typename": "EventNode",
-                            "name": "this should be the second",
-                        }
-                    },
-                    {
-                        "node": {
-                            "__typename": "EventGroupNode",
-                            "name": "this should be the third",
-                        }
-                    },
-                    {
-                        "node": {
-                            "__typename": "EventNode",
-                            "name": "this should be the fourth",
-                        }
-                    },
-                ]
-            }
-        }
-    }
-}
-
-snapshots["test_child_query 1"] = {
-    "data": {
-        "child": {
-            "birthyear": 2019,
-            "name": "Richard Hayes",
-            "postalCode": "57776",
-            "relationships": {
-                "edges": [
-                    {
-                        "node": {
-                            "guardian": {
-                                "email": "michellewalker@example.net",
-                                "firstName": "Denise",
-                                "lastName": "Thompson",
-                                "phoneNumber": "001-206-575-0649x7638",
-                            },
-                            "type": "OTHER_RELATION",
-                        }
-                    }
-                ]
-            },
-        }
-    }
-}
-
-snapshots["test_child_query_not_own_child_project_user 1"] = {
-    "data": {
-        "child": {
-            "birthyear": 2019,
-            "name": "Richard Hayes",
-            "postalCode": "57776",
-            "relationships": {
-                "edges": [
-                    {
-                        "node": {
-                            "guardian": {
-                                "email": "blake64@example.net",
-                                "firstName": "Timothy",
-                                "lastName": "Baldwin",
-                                "phoneNumber": "480.934.6697",
-                            },
-                            "type": "PARENT",
-                        }
-                    }
-                ]
-            },
-        }
-    }
-}
-
-snapshots["test_children_offset_pagination[10-None] 1"] = {
-    "data": {
-        "children": {
-            "edges": [
-                {"node": {"name": "1"}},
-                {"node": {"name": "2"}},
-                {"node": {"name": "3"}},
-                {"node": {"name": "4"}},
-                {"node": {"name": "5"}},
-            ]
-        }
-    }
-}
-
-snapshots["test_children_offset_pagination[2-2] 1"] = {
-    "data": {"children": {"edges": [{"node": {"name": "3"}}, {"node": {"name": "4"}}]}}
-}
-
-snapshots["test_children_offset_pagination[2-None] 1"] = {
-    "data": {"children": {"edges": [{"node": {"name": "1"}}, {"node": {"name": "2"}}]}}
-}
-
-snapshots["test_children_offset_pagination[None-2] 1"] = {
-    "data": {
-        "children": {
-            "edges": [
-                {"node": {"name": "3"}},
-                {"node": {"name": "4"}},
-                {"node": {"name": "5"}},
-            ]
-        }
-    }
-}
-
-snapshots["test_children_offset_pagination[None-5] 1"] = {
-    "data": {"children": {"edges": []}}
-}
-
-snapshots["test_children_project_filter 1"] = {
-    "data": {"children": {"edges": [{"node": {"name": "Only I should be returned"}}]}}
-}
-
-snapshots["test_children_query_normal_user 1"] = {
-    "data": {
-        "children": {
-            "edges": [
-                {
-                    "node": {
-                        "birthyear": 2019,
-                        "name": "Richard Hayes",
-                        "postalCode": "57776",
-                        "relationships": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "guardian": {
-                                            "email": "michellewalker@example.net",
-                                            "firstName": "Denise",
-                                            "lastName": "Thompson",
-                                            "phoneNumber": "001-206-575-0649x7638",
-                                        },
-                                        "type": "OTHER_RELATION",
-                                    }
+                        'node': {
+                            '__typename': 'EnrolmentNode',
+                            'occurrence': {
+                                'event': {
+                                    'name': '2/5'
                                 }
-                            ]
-                        },
+                            }
+                        }
+                    },
+                    {
+                        'node': {
+                            '__typename': 'TicketmasterEnrolmentNode',
+                            'createdAt': '2020-12-12T00:00:00+00:00',
+                            'event': {
+                                'name': '3/5'
+                            }
+                        }
+                    },
+                    {
+                        'node': {
+                            '__typename': 'EnrolmentNode',
+                            'occurrence': {
+                                'event': {
+                                    'name': '4/5'
+                                }
+                            }
+                        }
+                    },
+                    {
+                        'node': {
+                            '__typename': 'TicketmasterEnrolmentNode',
+                            'createdAt': '2020-12-12T00:00:00+00:00',
+                            'event': {
+                                'name': '5/5'
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['test_add_child_mutation 1'] = {
+    'data': {
+        'addChild': {
+            'child': {
+                'birthyear': 2020,
+                'name': 'Pekka',
+                'postalCode': '00820'
+            }
+        }
+    }
+}
+
+snapshots['test_available_events_and_event_groups 1'] = {
+    'data': {
+        'child': {
+            'availableEventsAndEventGroups': {
+                'edges': [
+                    {
+                        'node': {
+                            '__typename': 'EventGroupNode',
+                            'name': 'this should be the first'
+                        }
+                    },
+                    {
+                        'node': {
+                            '__typename': 'EventNode',
+                            'name': 'this should be the second'
+                        }
+                    },
+                    {
+                        'node': {
+                            '__typename': 'EventGroupNode',
+                            'name': 'this should be the third'
+                        }
+                    },
+                    {
+                        'node': {
+                            '__typename': 'EventNode',
+                            'name': 'this should be the fourth'
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['test_child_query 1'] = {
+    'data': {
+        'child': {
+            'birthyear': 2019,
+            'name': 'Richard Hayes',
+            'postalCode': '57776',
+            'relationships': {
+                'edges': [
+                    {
+                        'node': {
+                            'guardian': {
+                                'email': 'michellewalker@example.net',
+                                'firstName': 'Denise',
+                                'lastName': 'Thompson',
+                                'phoneNumber': '001-206-575-0649x7638'
+                            },
+                            'type': 'OTHER_RELATION'
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['test_child_query_not_own_child_project_user 1'] = {
+    'data': {
+        'child': {
+            'birthyear': 2019,
+            'name': 'Richard Hayes',
+            'postalCode': '57776',
+            'relationships': {
+                'edges': [
+                    {
+                        'node': {
+                            'guardian': {
+                                'email': 'blake64@example.net',
+                                'firstName': 'Timothy',
+                                'lastName': 'Baldwin',
+                                'phoneNumber': '480.934.6697'
+                            },
+                            'type': 'PARENT'
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['test_children_offset_pagination[10-None] 1'] = {
+    'data': {
+        'children': {
+            'edges': [
+                {
+                    'node': {
+                        'name': '1'
+                    }
+                },
+                {
+                    'node': {
+                        'name': '2'
+                    }
+                },
+                {
+                    'node': {
+                        'name': '3'
+                    }
+                },
+                {
+                    'node': {
+                        'name': '4'
+                    }
+                },
+                {
+                    'node': {
+                        'name': '5'
                     }
                 }
             ]
@@ -216,47 +196,18 @@ snapshots["test_children_query_normal_user 1"] = {
     }
 }
 
-snapshots["test_children_query_ordering 1"] = {
-    "data": {
-        "children": {
-            "edges": [
-                {"node": {"createdAt": "2020-11-11T00:00:00+00:00", "name": ""}},
-                {"node": {"createdAt": "2020-12-12T00:00:00+00:00", "name": ""}},
-                {"node": {"createdAt": "2020-12-12T00:00:00+00:00", "name": "Alpha"}},
-                {"node": {"createdAt": "2020-12-12T00:00:00+00:00", "name": "Bravo"}},
-                {"node": {"createdAt": "2020-12-12T00:00:00+00:00", "name": "Bravo"}},
-                {"node": {"createdAt": "2020-11-11T00:00:00+00:00", "name": "Charlie"}},
-                {"node": {"createdAt": "2020-12-12T00:00:00+00:00", "name": "Charlie"}},
-                {"node": {"createdAt": "2020-12-12T00:00:00+00:00", "name": "Delta"}},
-            ]
-        }
-    }
-}
-
-snapshots["test_children_query_project_user 1"] = {
-    "data": {
-        "children": {
-            "edges": [
+snapshots['test_children_offset_pagination[2-2] 1'] = {
+    'data': {
+        'children': {
+            'edges': [
                 {
-                    "node": {
-                        "birthyear": 2020,
-                        "name": "Same project - Should be returned 1/1",
-                        "postalCode": "73557",
-                        "relationships": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "guardian": {
-                                            "email": "funderwood@example.com",
-                                            "firstName": "Blake",
-                                            "lastName": "Newton",
-                                            "phoneNumber": "497-963-8034x6697",
-                                        },
-                                        "type": "PARENT",
-                                    }
-                                }
-                            ]
-                        },
+                    'node': {
+                        'name': '3'
+                    }
+                },
+                {
+                    'node': {
+                        'name': '4'
                     }
                 }
             ]
@@ -264,521 +215,808 @@ snapshots["test_children_query_project_user 1"] = {
     }
 }
 
-snapshots["test_children_query_project_user_and_guardian 1"] = {
-    "data": {
-        "children": {
-            "edges": [
+snapshots['test_children_offset_pagination[2-None] 1'] = {
+    'data': {
+        'children': {
+            'edges': [
                 {
-                    "node": {
-                        "birthyear": 2021,
-                        "name": "Not own child same project - Should be returned 3/3",
-                        "postalCode": "11715",
-                        "relationships": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "guardian": {
-                                            "email": "anthonycross@example.com",
-                                            "firstName": "Sarah",
-                                            "lastName": "Larsen",
-                                            "phoneNumber": "4895817101",
-                                        },
-                                        "type": "OTHER_RELATION",
-                                    }
-                                }
-                            ]
-                        },
+                    'node': {
+                        'name': '1'
                     }
                 },
                 {
-                    "node": {
-                        "birthyear": 2022,
-                        "name": "Own child another project - Should be returned 2/3",
-                        "postalCode": "34669",
-                        "relationships": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "guardian": {
-                                            "email": "michellewalker@example.net",
-                                            "firstName": "Michael",
-                                            "lastName": "Patton",
-                                            "phoneNumber": "235.857.7767x124",
-                                        },
-                                        "type": "OTHER_GUARDIAN",
-                                    }
-                                }
-                            ]
-                        },
+                    'node': {
+                        'name': '2'
                     }
-                },
-                {
-                    "node": {
-                        "birthyear": 2021,
-                        "name": "Own child same project - Should be returned 1/3",
-                        "postalCode": "06497",
-                        "relationships": {
-                            "edges": [
-                                {
-                                    "node": {
-                                        "guardian": {
-                                            "email": "michellewalker@example.net",
-                                            "firstName": "Michael",
-                                            "lastName": "Patton",
-                                            "phoneNumber": "235.857.7767x124",
-                                        },
-                                        "type": "OTHER_GUARDIAN",
-                                    }
-                                }
-                            ]
-                        },
-                    }
-                },
+                }
             ]
         }
     }
 }
 
-snapshots["test_children_total_count[None] 1"] = {"data": {"children": {"count": 5}}}
-
-snapshots["test_children_total_count[first] 1"] = {"data": {"children": {"count": 5}}}
-
-snapshots["test_children_total_count[limit] 1"] = {"data": {"children": {"count": 5}}}
-
-snapshots["test_delete_child_mutation 1"] = {
-    "data": {"deleteChild": {"__typename": "DeleteChildMutationPayload"}}
-}
-
-snapshots["test_get_available_events 1"] = {
-    "data": {
-        "child": {
-            "availableEvents": {
-                "edges": [
-                    {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "occurrences": {
-                                "edges": [{"node": {"remainingCapacity": 46}}]
-                            },
-                        }
+snapshots['test_children_offset_pagination[None-2] 1'] = {
+    'data': {
+        'children': {
+            'edges': [
+                {
+                    'node': {
+                        'name': '3'
                     }
-                ]
-            },
-            "occurrences": {"edges": [{"node": {"time": "2020-12-12T00:00:00+00:00"}}]},
-            "pastEvents": {"edges": []},
+                },
+                {
+                    'node': {
+                        'name': '4'
+                    }
+                },
+                {
+                    'node': {
+                        'name': '5'
+                    }
+                }
+            ]
         }
     }
 }
 
-snapshots["test_get_past_events 1"] = {
-    "data": {
-        "child": {
-            "availableEvents": {"edges": []},
-            "occurrences": {
-                "edges": [
-                    {"node": {"time": "2020-12-11T22:59:00+00:00"}},
-                    {"node": {"time": "2020-12-11T23:01:00+00:00"}},
-                ]
-            },
-            "pastEvents": {
-                "edges": [
+snapshots['test_children_offset_pagination[None-5] 1'] = {
+    'data': {
+        'children': {
+            'edges': [
+            ]
+        }
+    }
+}
+
+snapshots['test_children_project_filter 1'] = {
+    'data': {
+        'children': {
+            'edges': [
+                {
+                    'node': {
+                        'name': 'Only I should be returned'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['test_children_query_normal_user 1'] = {
+    'data': {
+        'children': {
+            'edges': [
+                {
+                    'node': {
+                        'birthyear': 2019,
+                        'name': 'Richard Hayes',
+                        'postalCode': '57776',
+                        'relationships': {
+                            'edges': [
+                                {
+                                    'node': {
+                                        'guardian': {
+                                            'email': 'michellewalker@example.net',
+                                            'firstName': 'Denise',
+                                            'lastName': 'Thompson',
+                                            'phoneNumber': '001-206-575-0649x7638'
+                                        },
+                                        'type': 'OTHER_RELATION'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['test_children_query_ordering 1'] = {
+    'data': {
+        'children': {
+            'edges': [
+                {
+                    'node': {
+                        'createdAt': '2020-11-11T00:00:00+00:00',
+                        'name': ''
+                    }
+                },
+                {
+                    'node': {
+                        'createdAt': '2020-12-12T00:00:00+00:00',
+                        'name': ''
+                    }
+                },
+                {
+                    'node': {
+                        'createdAt': '2020-12-12T00:00:00+00:00',
+                        'name': 'Alpha'
+                    }
+                },
+                {
+                    'node': {
+                        'createdAt': '2020-12-12T00:00:00+00:00',
+                        'name': 'Bravo'
+                    }
+                },
+                {
+                    'node': {
+                        'createdAt': '2020-12-12T00:00:00+00:00',
+                        'name': 'Bravo'
+                    }
+                },
+                {
+                    'node': {
+                        'createdAt': '2020-11-11T00:00:00+00:00',
+                        'name': 'Charlie'
+                    }
+                },
+                {
+                    'node': {
+                        'createdAt': '2020-12-12T00:00:00+00:00',
+                        'name': 'Charlie'
+                    }
+                },
+                {
+                    'node': {
+                        'createdAt': '2020-12-12T00:00:00+00:00',
+                        'name': 'Delta'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['test_children_query_project_user 1'] = {
+    'data': {
+        'children': {
+            'edges': [
+                {
+                    'node': {
+                        'birthyear': 2020,
+                        'name': 'Same project - Should be returned 1/1',
+                        'postalCode': '73557',
+                        'relationships': {
+                            'edges': [
+                                {
+                                    'node': {
+                                        'guardian': {
+                                            'email': 'funderwood@example.com',
+                                            'firstName': 'Blake',
+                                            'lastName': 'Newton',
+                                            'phoneNumber': '497-963-8034x6697'
+                                        },
+                                        'type': 'PARENT'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['test_children_query_project_user_and_guardian 1'] = {
+    'data': {
+        'children': {
+            'edges': [
+                {
+                    'node': {
+                        'birthyear': 2021,
+                        'name': 'Not own child same project - Should be returned 3/3',
+                        'postalCode': '11715',
+                        'relationships': {
+                            'edges': [
+                                {
+                                    'node': {
+                                        'guardian': {
+                                            'email': 'anthonycross@example.com',
+                                            'firstName': 'Sarah',
+                                            'lastName': 'Larsen',
+                                            'phoneNumber': '4895817101'
+                                        },
+                                        'type': 'OTHER_RELATION'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    'node': {
+                        'birthyear': 2022,
+                        'name': 'Own child another project - Should be returned 2/3',
+                        'postalCode': '34669',
+                        'relationships': {
+                            'edges': [
+                                {
+                                    'node': {
+                                        'guardian': {
+                                            'email': 'michellewalker@example.net',
+                                            'firstName': 'Michael',
+                                            'lastName': 'Patton',
+                                            'phoneNumber': '235.857.7767x124'
+                                        },
+                                        'type': 'OTHER_GUARDIAN'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    'node': {
+                        'birthyear': 2021,
+                        'name': 'Own child same project - Should be returned 1/3',
+                        'postalCode': '06497',
+                        'relationships': {
+                            'edges': [
+                                {
+                                    'node': {
+                                        'guardian': {
+                                            'email': 'michellewalker@example.net',
+                                            'firstName': 'Michael',
+                                            'lastName': 'Patton',
+                                            'phoneNumber': '235.857.7767x124'
+                                        },
+                                        'type': 'OTHER_GUARDIAN'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['test_children_total_count[None] 1'] = {
+    'data': {
+        'children': {
+            'count': 5
+        }
+    }
+}
+
+snapshots['test_children_total_count[first] 1'] = {
+    'data': {
+        'children': {
+            'count': 5
+        }
+    }
+}
+
+snapshots['test_children_total_count[limit] 1'] = {
+    'data': {
+        'children': {
+            'count': 5
+        }
+    }
+}
+
+snapshots['test_delete_child_mutation 1'] = {
+    'data': {
+        'deleteChild': {
+            '__typename': 'DeleteChildMutationPayload'
+        }
+    }
+}
+
+snapshots['test_get_available_events 1'] = {
+    'data': {
+        'child': {
+            'availableEvents': {
+                'edges': [
                     {
-                        "node": {
-                            "createdAt": "2020-12-12T00:00:00+00:00",
-                            "name": "enrolled occurrence in the past",
-                            "occurrences": {
-                                "edges": [
-                                    {"node": {"remainingCapacity": 12}},
-                                    {"node": {"remainingCapacity": 13}},
+                        'node': {
+                            'createdAt': '2020-12-12T00:00:00+00:00',
+                            'occurrences': {
+                                'edges': [
+                                    {
+                                        'node': {
+                                            'remainingCapacity': 46
+                                        }
+                                    }
                                 ]
-                            },
+                            }
                         }
                     }
                 ]
             },
-        }
-    }
-}
-
-snapshots["test_get_past_events_including_external_ticket_system_events 1"] = {
-    "data": {
-        "child": {
-            "pastEvents": {
-                "edges": [
-                    {"node": {"name": "Expected as 1/4"}},
-                    {"node": {"name": "Expected as 2/4"}},
-                    {"node": {"name": "Expected as 3/4"}},
-                    {"node": {"name": "Expected as 4/4"}},
+            'occurrences': {
+                'edges': [
+                    {
+                        'node': {
+                            'time': '2020-12-12T00:00:00+00:00'
+                        }
+                    }
+                ]
+            },
+            'pastEvents': {
+                'edges': [
                 ]
             }
         }
     }
 }
 
-snapshots["test_submit_children_and_guardian 1"] = {
-    "data": {
-        "submitChildrenAndGuardian": {
-            "children": [
-                {
-                    "birthyear": 2020,
-                    "name": "Matti",
-                    "postalCode": "00840",
-                    "relationships": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "guardian": {
-                                        "email": "michellewalker@example.net",
-                                        "firstName": "Gulle",
-                                        "lastName": "Guardian",
-                                        "phoneNumber": "777-777777",
+snapshots['test_get_past_events 1'] = {
+    'data': {
+        'child': {
+            'availableEvents': {
+                'edges': [
+                ]
+            },
+            'occurrences': {
+                'edges': [
+                    {
+                        'node': {
+                            'time': '2020-12-11T22:59:00+00:00'
+                        }
+                    },
+                    {
+                        'node': {
+                            'time': '2020-12-11T23:01:00+00:00'
+                        }
+                    }
+                ]
+            },
+            'pastEvents': {
+                'edges': [
+                    {
+                        'node': {
+                            'createdAt': '2020-12-12T00:00:00+00:00',
+                            'name': 'enrolled occurrence in the past',
+                            'occurrences': {
+                                'edges': [
+                                    {
+                                        'node': {
+                                            'remainingCapacity': 12
+                                        }
                                     },
-                                    "type": "OTHER_GUARDIAN",
+                                    {
+                                        'node': {
+                                            'remainingCapacity': 13
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['test_get_past_events_including_external_ticket_system_events 1'] = {
+    'data': {
+        'child': {
+            'pastEvents': {
+                'edges': [
+                    {
+                        'node': {
+                            'name': 'Expected as 1/4'
+                        }
+                    },
+                    {
+                        'node': {
+                            'name': 'Expected as 2/4'
+                        }
+                    },
+                    {
+                        'node': {
+                            'name': 'Expected as 3/4'
+                        }
+                    },
+                    {
+                        'node': {
+                            'name': 'Expected as 4/4'
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['test_submit_children_and_guardian 1'] = {
+    'data': {
+        'submitChildrenAndGuardian': {
+            'children': [
+                {
+                    'birthyear': 2020,
+                    'name': 'Matti',
+                    'postalCode': '00840',
+                    'relationships': {
+                        'edges': [
+                            {
+                                'node': {
+                                    'guardian': {
+                                        'email': 'michellewalker@example.net',
+                                        'firstName': 'Gulle',
+                                        'lastName': 'Guardian',
+                                        'phoneNumber': '777-777777'
+                                    },
+                                    'type': 'OTHER_GUARDIAN'
                                 }
                             }
                         ]
-                    },
+                    }
                 },
                 {
-                    "birthyear": 2020,
-                    "name": "Jussi",
-                    "postalCode": "00820",
-                    "relationships": {
-                        "edges": [
+                    'birthyear': 2020,
+                    'name': 'Jussi',
+                    'postalCode': '00820',
+                    'relationships': {
+                        'edges': [
                             {
-                                "node": {
-                                    "guardian": {
-                                        "email": "michellewalker@example.net",
-                                        "firstName": "Gulle",
-                                        "lastName": "Guardian",
-                                        "phoneNumber": "777-777777",
+                                'node': {
+                                    'guardian': {
+                                        'email': 'michellewalker@example.net',
+                                        'firstName': 'Gulle',
+                                        'lastName': 'Guardian',
+                                        'phoneNumber': '777-777777'
                                     },
-                                    "type": None,
+                                    'type': None
                                 }
                             }
                         ]
-                    },
-                },
+                    }
+                }
             ],
-            "guardian": {
-                "email": "michellewalker@example.net",
-                "firstName": "Gulle",
-                "languagesSpokenAtHome": {
-                    "edges": [
-                        {"node": {"alpha3Code": "swe"}},
-                        {"node": {"alpha3Code": "fin"}},
+            'guardian': {
+                'email': 'michellewalker@example.net',
+                'firstName': 'Gulle',
+                'languagesSpokenAtHome': {
+                    'edges': [
+                        {
+                            'node': {
+                                'alpha3Code': 'swe'
+                            }
+                        },
+                        {
+                            'node': {
+                                'alpha3Code': 'fin'
+                            }
+                        }
                     ]
                 },
-                "lastName": "Guardian",
-                "phoneNumber": "777-777777",
-            },
+                'lastName': 'Guardian',
+                'phoneNumber': '777-777777'
+            }
         }
     }
 }
 
-snapshots["test_submit_children_and_guardian_with_falsy_email[None] 1"] = {
-    "data": {
-        "submitChildrenAndGuardian": {
-            "children": [
+snapshots['test_submit_children_and_guardian_with_falsy_email[None] 1'] = {
+    'data': {
+        'submitChildrenAndGuardian': {
+            'children': [
                 {
-                    "birthyear": 2020,
-                    "name": "Matti",
-                    "postalCode": "00840",
-                    "relationships": {
-                        "edges": [
+                    'birthyear': 2020,
+                    'name': 'Matti',
+                    'postalCode': '00840',
+                    'relationships': {
+                        'edges': [
                             {
-                                "node": {
-                                    "guardian": {
-                                        "email": "michellewalker@example.net",
-                                        "firstName": "Gulle",
-                                        "lastName": "Guardian",
-                                        "phoneNumber": "777-777777",
+                                'node': {
+                                    'guardian': {
+                                        'email': 'michellewalker@example.net',
+                                        'firstName': 'Gulle',
+                                        'lastName': 'Guardian',
+                                        'phoneNumber': '777-777777'
                                     },
-                                    "type": "OTHER_GUARDIAN",
+                                    'type': 'OTHER_GUARDIAN'
                                 }
                             }
                         ]
-                    },
+                    }
                 },
                 {
-                    "birthyear": 2020,
-                    "name": "Jussi",
-                    "postalCode": "00820",
-                    "relationships": {
-                        "edges": [
+                    'birthyear': 2020,
+                    'name': 'Jussi',
+                    'postalCode': '00820',
+                    'relationships': {
+                        'edges': [
                             {
-                                "node": {
-                                    "guardian": {
-                                        "email": "michellewalker@example.net",
-                                        "firstName": "Gulle",
-                                        "lastName": "Guardian",
-                                        "phoneNumber": "777-777777",
+                                'node': {
+                                    'guardian': {
+                                        'email': 'michellewalker@example.net',
+                                        'firstName': 'Gulle',
+                                        'lastName': 'Guardian',
+                                        'phoneNumber': '777-777777'
                                     },
-                                    "type": None,
+                                    'type': None
                                 }
                             }
                         ]
-                    },
-                },
+                    }
+                }
             ],
-            "guardian": {
-                "email": "michellewalker@example.net",
-                "firstName": "Gulle",
-                "languagesSpokenAtHome": {"edges": []},
-                "lastName": "Guardian",
-                "phoneNumber": "777-777777",
-            },
+            'guardian': {
+                'email': 'michellewalker@example.net',
+                'firstName': 'Gulle',
+                'languagesSpokenAtHome': {
+                    'edges': [
+                    ]
+                },
+                'lastName': 'Guardian',
+                'phoneNumber': '777-777777'
+            }
         }
     }
 }
 
-snapshots["test_submit_children_and_guardian_with_falsy_email[] 1"] = {
-    "data": {
-        "submitChildrenAndGuardian": {
-            "children": [
+snapshots['test_submit_children_and_guardian_with_falsy_email[] 1'] = {
+    'data': {
+        'submitChildrenAndGuardian': {
+            'children': [
                 {
-                    "birthyear": 2020,
-                    "name": "Matti",
-                    "postalCode": "00840",
-                    "relationships": {
-                        "edges": [
+                    'birthyear': 2020,
+                    'name': 'Matti',
+                    'postalCode': '00840',
+                    'relationships': {
+                        'edges': [
                             {
-                                "node": {
-                                    "guardian": {
-                                        "email": "michellewalker@example.net",
-                                        "firstName": "Gulle",
-                                        "lastName": "Guardian",
-                                        "phoneNumber": "777-777777",
+                                'node': {
+                                    'guardian': {
+                                        'email': 'michellewalker@example.net',
+                                        'firstName': 'Gulle',
+                                        'lastName': 'Guardian',
+                                        'phoneNumber': '777-777777'
                                     },
-                                    "type": "OTHER_GUARDIAN",
+                                    'type': 'OTHER_GUARDIAN'
                                 }
                             }
                         ]
-                    },
+                    }
                 },
                 {
-                    "birthyear": 2020,
-                    "name": "Jussi",
-                    "postalCode": "00820",
-                    "relationships": {
-                        "edges": [
+                    'birthyear': 2020,
+                    'name': 'Jussi',
+                    'postalCode': '00820',
+                    'relationships': {
+                        'edges': [
                             {
-                                "node": {
-                                    "guardian": {
-                                        "email": "michellewalker@example.net",
-                                        "firstName": "Gulle",
-                                        "lastName": "Guardian",
-                                        "phoneNumber": "777-777777",
+                                'node': {
+                                    'guardian': {
+                                        'email': 'michellewalker@example.net',
+                                        'firstName': 'Gulle',
+                                        'lastName': 'Guardian',
+                                        'phoneNumber': '777-777777'
                                     },
-                                    "type": None,
+                                    'type': None
                                 }
                             }
                         ]
-                    },
-                },
+                    }
+                }
             ],
-            "guardian": {
-                "email": "michellewalker@example.net",
-                "firstName": "Gulle",
-                "languagesSpokenAtHome": {"edges": []},
-                "lastName": "Guardian",
-                "phoneNumber": "777-777777",
-            },
+            'guardian': {
+                'email': 'michellewalker@example.net',
+                'firstName': 'Gulle',
+                'languagesSpokenAtHome': {
+                    'edges': [
+                    ]
+                },
+                'lastName': 'Guardian',
+                'phoneNumber': '777-777777'
+            }
         }
     }
 }
 
-snapshots["test_submit_children_and_guardian_with_user_email 1"] = {
-    "data": {
-        "submitChildrenAndGuardian": {
-            "children": [
+snapshots['test_submit_children_and_guardian_with_user_email 1'] = {
+    'data': {
+        'submitChildrenAndGuardian': {
+            'children': [
                 {
-                    "birthyear": 2020,
-                    "name": "Matti",
-                    "postalCode": "00840",
-                    "relationships": {
-                        "edges": [
+                    'birthyear': 2020,
+                    'name': 'Matti',
+                    'postalCode': '00840',
+                    'relationships': {
+                        'edges': [
                             {
-                                "node": {
-                                    "guardian": {
-                                        "email": "michellewalker@example.net",
-                                        "firstName": "Gulle",
-                                        "lastName": "Guardian",
-                                        "phoneNumber": "777-777777",
+                                'node': {
+                                    'guardian': {
+                                        'email': 'michellewalker@example.net',
+                                        'firstName': 'Gulle',
+                                        'lastName': 'Guardian',
+                                        'phoneNumber': '777-777777'
                                     },
-                                    "type": "OTHER_GUARDIAN",
+                                    'type': 'OTHER_GUARDIAN'
                                 }
                             }
                         ]
-                    },
+                    }
                 },
                 {
-                    "birthyear": 2020,
-                    "name": "Jussi",
-                    "postalCode": "00820",
-                    "relationships": {
-                        "edges": [
+                    'birthyear': 2020,
+                    'name': 'Jussi',
+                    'postalCode': '00820',
+                    'relationships': {
+                        'edges': [
                             {
-                                "node": {
-                                    "guardian": {
-                                        "email": "michellewalker@example.net",
-                                        "firstName": "Gulle",
-                                        "lastName": "Guardian",
-                                        "phoneNumber": "777-777777",
+                                'node': {
+                                    'guardian': {
+                                        'email': 'michellewalker@example.net',
+                                        'firstName': 'Gulle',
+                                        'lastName': 'Guardian',
+                                        'phoneNumber': '777-777777'
                                     },
-                                    "type": None,
+                                    'type': None
                                 }
                             }
                         ]
-                    },
-                },
+                    }
+                }
             ],
-            "guardian": {
-                "email": "michellewalker@example.net",
-                "firstName": "Gulle",
-                "languagesSpokenAtHome": {"edges": []},
-                "lastName": "Guardian",
-                "phoneNumber": "777-777777",
-            },
+            'guardian': {
+                'email': 'michellewalker@example.net',
+                'firstName': 'Gulle',
+                'languagesSpokenAtHome': {
+                    'edges': [
+                    ]
+                },
+                'lastName': 'Guardian',
+                'phoneNumber': '777-777777'
+            }
         }
     }
 }
 
-snapshots["test_submit_children_and_guardian_without_email 1"] = {
-    "data": {
-        "submitChildrenAndGuardian": {
-            "children": [
+snapshots['test_submit_children_and_guardian_without_email 1'] = {
+    'data': {
+        'submitChildrenAndGuardian': {
+            'children': [
                 {
-                    "birthyear": 2020,
-                    "name": "Matti",
-                    "postalCode": "00840",
-                    "relationships": {
-                        "edges": [
+                    'birthyear': 2020,
+                    'name': 'Matti',
+                    'postalCode': '00840',
+                    'relationships': {
+                        'edges': [
                             {
-                                "node": {
-                                    "guardian": {
-                                        "email": "michellewalker@example.net",
-                                        "firstName": "Gulle",
-                                        "lastName": "Guardian",
-                                        "phoneNumber": "777-777777",
+                                'node': {
+                                    'guardian': {
+                                        'email': 'michellewalker@example.net',
+                                        'firstName': 'Gulle',
+                                        'lastName': 'Guardian',
+                                        'phoneNumber': '777-777777'
                                     },
-                                    "type": "OTHER_GUARDIAN",
+                                    'type': 'OTHER_GUARDIAN'
                                 }
                             }
                         ]
-                    },
+                    }
                 },
                 {
-                    "birthyear": 2020,
-                    "name": "Jussi",
-                    "postalCode": "00820",
-                    "relationships": {
-                        "edges": [
+                    'birthyear': 2020,
+                    'name': 'Jussi',
+                    'postalCode': '00820',
+                    'relationships': {
+                        'edges': [
                             {
-                                "node": {
-                                    "guardian": {
-                                        "email": "michellewalker@example.net",
-                                        "firstName": "Gulle",
-                                        "lastName": "Guardian",
-                                        "phoneNumber": "777-777777",
+                                'node': {
+                                    'guardian': {
+                                        'email': 'michellewalker@example.net',
+                                        'firstName': 'Gulle',
+                                        'lastName': 'Guardian',
+                                        'phoneNumber': '777-777777'
                                     },
-                                    "type": None,
+                                    'type': None
                                 }
                             }
                         ]
-                    },
-                },
+                    }
+                }
             ],
-            "guardian": {
-                "email": "michellewalker@example.net",
-                "firstName": "Gulle",
-                "languagesSpokenAtHome": {"edges": []},
-                "lastName": "Guardian",
-                "phoneNumber": "777-777777",
-            },
+            'guardian': {
+                'email': 'michellewalker@example.net',
+                'firstName': 'Gulle',
+                'languagesSpokenAtHome': {
+                    'edges': [
+                    ]
+                },
+                'lastName': 'Guardian',
+                'phoneNumber': '777-777777'
+            }
         }
     }
 }
 
-snapshots["test_upcoming_events_and_event_groups 1"] = {
-    "data": {
-        "child": {
-            "upcomingEventsAndEventGroups": {
-                "edges": [
+snapshots['test_upcoming_events_and_event_groups 1'] = {
+    'data': {
+        'child': {
+            'upcomingEventsAndEventGroups': {
+                'edges': [
                     {
-                        "node": {
-                            "__typename": "EventGroupNode",
-                            "canChildEnroll": True,
-                            "name": "This should be the 1/8",
+                        'node': {
+                            '__typename': 'EventGroupNode',
+                            'canChildEnroll': True,
+                            'name': 'This should be the 1/8'
                         }
                     },
                     {
-                        "node": {
-                            "__typename": "EventNode",
-                            "canChildEnroll": True,
-                            "name": "This should be 2/8",
+                        'node': {
+                            '__typename': 'EventNode',
+                            'canChildEnroll': True,
+                            'name': 'This should be 2/8'
                         }
                     },
                     {
-                        "node": {
-                            "__typename": "EventNode",
-                            "canChildEnroll": True,
-                            "name": "This should be 3/8",
+                        'node': {
+                            '__typename': 'EventNode',
+                            'canChildEnroll': True,
+                            'name': 'This should be 3/8'
                         }
                     },
                     {
-                        "node": {
-                            "__typename": "EventNode",
-                            "canChildEnroll": True,
-                            "name": "This should be 4/8",
+                        'node': {
+                            '__typename': 'EventNode',
+                            'canChildEnroll': True,
+                            'name': 'This should be 4/8'
                         }
                     },
                     {
-                        "node": {
-                            "__typename": "EventNode",
-                            "canChildEnroll": True,
-                            "name": "This should be 5/8",
+                        'node': {
+                            '__typename': 'EventNode',
+                            'canChildEnroll': True,
+                            'name': 'This should be 5/8'
                         }
                     },
                     {
-                        "node": {
-                            "__typename": "EventGroupNode",
-                            "canChildEnroll": True,
-                            "name": "This should be 6/8",
+                        'node': {
+                            '__typename': 'EventGroupNode',
+                            'canChildEnroll': True,
+                            'name': 'This should be 6/8'
                         }
                     },
                     {
-                        "node": {
-                            "__typename": "EventNode",
-                            "canChildEnroll": False,
-                            "name": "This should be 7/8",
+                        'node': {
+                            '__typename': 'EventNode',
+                            'canChildEnroll': False,
+                            'name': 'This should be 7/8'
                         }
                     },
                     {
-                        "node": {
-                            "__typename": "EventGroupNode",
-                            "canChildEnroll": False,
-                            "name": "This should be 8/8",
+                        'node': {
+                            '__typename': 'EventGroupNode',
+                            'canChildEnroll': False,
+                            'name': 'This should be 8/8'
                         }
-                    },
+                    }
                 ]
             }
         }
     }
 }
 
-snapshots["test_update_child_mutation 1"] = {
-    "data": {
-        "updateChild": {
-            "child": {"birthyear": 2021, "name": "Matti", "postalCode": "00840"}
+snapshots['test_update_child_mutation 1'] = {
+    'data': {
+        'updateChild': {
+            'child': {
+                'birthyear': 2021,
+                'name': 'Matti',
+                'postalCode': '00840'
+            }
         }
     }
 }
 
-snapshots["test_update_child_mutation_should_have_no_required_fields 1"] = {
-    "data": {
-        "updateChild": {
-            "child": {"birthyear": 2021, "name": "Derek Perry", "postalCode": "70117"}
+snapshots['test_update_child_mutation_should_have_no_required_fields 1'] = {
+    'data': {
+        'updateChild': {
+            'child': {
+                'birthyear': 2021,
+                'name': 'Derek Perry',
+                'postalCode': '70117'
+            }
         }
     }
 }

--- a/children/tests/test_api.py
+++ b/children/tests/test_api.py
@@ -1165,10 +1165,10 @@ def test_get_available_events(
     unpublished_event,
     child_with_user_guardian,
     project,
+    another_project,
     venue,
 ):
     variables = {"id": to_global_id("ChildNode", child_with_user_guardian.id)}
-    next_project = ProjectFactory(year=2021)
     # Unpublished occurrences
     OccurrenceFactory(time=timezone.now(), event=unpublished_event, venue=venue)
 
@@ -1190,7 +1190,7 @@ def test_get_available_events(
     OccurrenceFactory(
         time=timezone.now(),
         event__published_at=timezone.now(),
-        event__project=next_project,
+        event__project=another_project,
         venue=venue,
     )
 

--- a/events/schema.py
+++ b/events/schema.py
@@ -1307,7 +1307,7 @@ class AddEventGroupMutation(graphene.relay.ClientIDMutation):
         event_group = EventGroup.objects.create_translatable_object(**kwargs)
 
         logger.info(
-            f"user {user.uuid} added event group {event_group} " f"with data {kwargs}"
+            f"user {user.uuid} added event group {event_group} with data {kwargs}"
         )
 
         return AddEventGroupMutation(event_group=event_group)
@@ -1342,7 +1342,7 @@ class UpdateEventGroupMutation(graphene.relay.ClientIDMutation):
         update_object_with_translations(event_group, kwargs)
 
         logger.info(
-            f"user {user.uuid} updated event group {event_group} " f"with data {kwargs}"
+            f"user {user.uuid} updated event group {event_group} with data {kwargs}"
         )
 
         return UpdateEventGroupMutation(event_group=event_group)

--- a/events/tests/snapshots/snap_test_api.py
+++ b/events/tests/snapshots/snap_test_api.py
@@ -161,7 +161,7 @@ snapshots['test_assign_ticket_system_password 1'] = {
     }
 }
 
-snapshots['test_child_enrol_occurence_from_different_project 1'] = {
+snapshots['test_child_enrol_occurrence_from_different_project 1'] = {
     'data': {
         'enrolOccurrence': {
             'enrolment': {

--- a/events/tests/snapshots/snap_test_notifications.py
+++ b/events/tests/snapshots/snap_test_notifications.py
@@ -4,21 +4,22 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
-snapshots["test_event_group_publish_notification 1"] = [
-    """kukkuu@example.com|['ywashington@example.com']|Event group published FI|
+snapshots['test_event_group_publish_notification 1'] = [
+    '''kukkuu@example.com|['ywashington@example.com']|Event group published FI|
         Event group FI: Scientist service wonder everything pay.
         Guardian FI: Denise Thompson (ywashington@example.com)
         Url: http://localhost:3000/fi/profile/child/Q2hpbGROb2RlOjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDMwOQ==/event-group/RXZlbnRHcm91cE5vZGU6Nzc3
         Events:
             Gas heavy affect difficult look can purpose care. 2020-12-12 00:00:00+00:00 http://localhost:3000/fi/profile/child/Q2hpbGROb2RlOjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDMwOQ==/event/RXZlbnROb2RlOjc3Nw==
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False"""
+        Obsoleted: False'''
 ]
 
-snapshots["test_event_group_republish_notification 1"] = [
-    """kukkuu@example.com|['ywashington@example.com']|Event group published FI|
+snapshots['test_event_group_republish_notification 1'] = [
+    '''kukkuu@example.com|['ywashington@example.com']|Event group published FI|
         Event group FI: Loss there southern newspaper force.
         Guardian FI: Denise Thompson (ywashington@example.com)
         Url: http://localhost:3000/fi/profile/child/Q2hpbGROb2RlOjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDMwOQ==/event-group/RXZlbnRHcm91cE5vZGU6Nzc3
@@ -26,185 +27,182 @@ snapshots["test_event_group_republish_notification 1"] = [
             If his their best. Election stay every something base. 2020-12-11 00:00:00+00:00 http://localhost:3000/fi/profile/child/Q2hpbGROb2RlOjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDMwOQ==/event/RXZlbnROb2RlOjc3Nw==
             Data control as receive. End available avoid girl middle. 2020-12-12 00:00:00+00:00 http://localhost:3000/fi/profile/child/Q2hpbGROb2RlOjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDMwOQ==/event/RXZlbnROb2RlOjc3OA==
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False"""
+        Obsoleted: False'''
 ]
 
-snapshots["test_feedback_notification 1"] = [
-    """kukkuu@example.com|['ywashington@example.com']|Feedback FI|
+snapshots['test_feedback_notification 1'] = [
+    '''kukkuu@example.com|['ywashington@example.com']|Feedback FI|
         Event FI: Entire increase thank certainly again.
         Guardian FI: (60, 15) I Should Receive A Notification (ywashington@example.com)
         Occurrence: 2020-12-11 23:00:00+00:00
         Child: Jose Kerr (2022)
         Enrolment: 2020-12-11 23:00:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
-    """kukkuu@example.com|['jennifer00@example.com']|Feedback FI|
+        Obsoleted: False''',
+    '''kukkuu@example.com|['jennifer00@example.com']|Feedback FI|
         Event FI: Special respond positive cold.
         Guardian FI: (30, 15) I Should Receive A Notification (jennifer00@example.com)
         Occurrence: 2020-12-11 23:30:00+00:00
         Child: Jason Williams (2021)
         Enrolment: 2020-12-11 23:30:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
-    """kukkuu@example.com|['aaronlee@example.org']|Feedback FI|
+        Obsoleted: False''',
+    '''kukkuu@example.com|['aaronlee@example.org']|Feedback FI|
         Event FI: Bar wish find system woman why. Whose age feeling speech.
         Guardian FI: (135, None) I Should Receive A Notification (aaronlee@example.org)
         Occurrence: 2020-12-11 21:45:00+00:00
         Child: Lindsey Baker (2022)
         Enrolment: 2020-12-11 21:45:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
-    """kukkuu@example.com|['dennis27@example.net']|Feedback FI|
+        Obsoleted: False''',
+    '''kukkuu@example.com|['dennis27@example.net']|Feedback FI|
         Event FI: Other poor specific carry owner sense other.
         Guardian FI: (10080, 15) I Should Receive A Notification (dennis27@example.net)
         Occurrence: 2020-12-05 00:00:00+00:00
         Child: Alexa Mcdonald (2018)
         Enrolment: 2020-12-05 00:00:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
+        Obsoleted: False'''
 ]
 
-snapshots["test_feedback_notification_instance_checks[False] 1"] = [
-    """kukkuu@example.com|['ywashington@example.com']|Feedback FI|
+snapshots['test_feedback_notification_instance_checks[False] 1'] = [
+    '''kukkuu@example.com|['ywashington@example.com']|Feedback FI|
         Event FI: Increase thank certainly again thought summer.
         Guardian FI: Denise Thompson (ywashington@example.com)
         Occurrence: 2020-12-11 00:00:00+00:00
         Child: Jose Kerr (2022)
         Enrolment: 2020-12-11 00:00:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False"""
+        Obsoleted: False'''
 ]
 
-snapshots["test_feedback_notification_instance_checks[True] 1"] = [
-    """kukkuu@example.com|['ywashington@example.com']|Feedback FI|
+snapshots['test_feedback_notification_instance_checks[True] 1'] = [
+    '''kukkuu@example.com|['ywashington@example.com']|Feedback FI|
         Event FI: Increase thank certainly again thought summer.
         Guardian FI: Denise Thompson (ywashington@example.com)
         Occurrence: 2020-12-11 00:00:00+00:00
         Child: Jose Kerr (2022)
         Enrolment: 2020-12-11 00:00:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
-    """kukkuu@example.com|['jennifer00@example.com']|Feedback FI|
+        Obsoleted: False''',
+    '''kukkuu@example.com|['jennifer00@example.com']|Feedback FI|
         Event FI: Special respond positive cold.
         Guardian FI: Danielle Reese (jennifer00@example.com)
         Occurrence: 2020-12-17 00:00:00+00:00
         Child: Jason Williams (2021)
         Enrolment: 2020-12-17 00:00:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
+        Obsoleted: False'''
 ]
 
-snapshots["test_occurrence_cancelled_notification[False] 1"] = [
-    """kukkuu@example.com|['michellewalker@example.net']|Occurrence cancelled FI|
+snapshots['test_occurrence_cancelled_notification[False] 1'] = [
+    '''kukkuu@example.com|['michellewalker@example.net']|Occurrence cancelled FI|
         Event FI: Decade either enter everything.
         Guardian FI: I Should Receive A Notification Valdez (michellewalker@example.net)
         Occurrence: 2020-12-12 01:00:00+00:00
         Child: Richard Hayes (2019)
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False"""
+        Obsoleted: False'''
 ]
 
-snapshots["test_occurrence_cancelled_notification[True] 1"] = [
-    """kukkuu@example.com|['michellewalker@example.net']|Occurrence cancelled FI|
+snapshots['test_occurrence_cancelled_notification[True] 1'] = [
+    '''kukkuu@example.com|['michellewalker@example.net']|Occurrence cancelled FI|
         Event FI: Decade either enter everything.
         Guardian FI: I Should Receive A Notification Valdez (michellewalker@example.net)
         Occurrence: 2020-12-12 01:00:00+00:00
         Child: Richard Hayes (2019)
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False"""
+        Obsoleted: False'''
 ]
 
-snapshots["test_occurrence_enrolment_notifications_on_model_level[None] 1"] = [
-    """kukkuu@example.com|['michellewalker@example.net']|Occurrence enrolment FI|
+snapshots['test_occurrence_enrolment_notifications_on_model_level[None] 1'] = [
+    '''kukkuu@example.com|['michellewalker@example.net']|Occurrence enrolment FI|
         Event FI: Poor lawyer treat free heart significant.
         Guardian FI: Ruth Palmer (michellewalker@example.net)
         Occurrence: 2020-12-12 00:00:00+00:00
         Child: Michael Pierce (2020)
         Occurrence URL: http://localhost:3000/fi/profile/child/Q2hpbGROb2RlOjU0NWM1ZmU1LTIzNWItNDZmZC1hYTJhLWNkNWRlNmZkZDBmYw==/occurrence/T2NjdXJyZW5jZU5vZGU6NzQ=
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False"""
+        Obsoleted: False'''
 ]
 
-snapshots[
-    "test_occurrence_enrolment_notifications_on_model_level[http://kultus-ui.test.kuva.hel.ninja/verify-ticket-endpoint/] 1"
-] = [
-    """kukkuu@example.com|['michellewalker@example.net']|Occurrence enrolment FI|
+snapshots['test_occurrence_enrolment_notifications_on_model_level[http://kultus-ui.test.kuva.hel.ninja/verify-ticket-endpoint/] 1'] = [
+    '''kukkuu@example.com|['michellewalker@example.net']|Occurrence enrolment FI|
         Event FI: Poor lawyer treat free heart significant.
         Guardian FI: Ruth Palmer (michellewalker@example.net)
         Occurrence: 2020-12-12 00:00:00+00:00
         Child: Michael Pierce (2020)
         Occurrence URL: http://localhost:3000/fi/profile/child/Q2hpbGROb2RlOjU0NWM1ZmU1LTIzNWItNDZmZC1hYTJhLWNkNWRlNmZkZDBmYw==/occurrence/T2NjdXJyZW5jZU5vZGU6NzQ=
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False"""
+        Obsoleted: False'''
 ]
 
-snapshots["test_occurrence_reminder_notification[None] 1"] = [
-    """kukkuu@example.com|['ywashington@example.com']|Occurrence reminder FI|
+snapshots['test_occurrence_reminder_notification[None] 1'] = [
+    '''kukkuu@example.com|['ywashington@example.com']|Occurrence reminder FI|
         Event FI: Entire increase thank certainly again.
         Guardian FI: I Should Receive A Notification (ywashington@example.com)
         Occurrence: 2020-12-19 00:00:00+00:00
         Child: Jose Kerr (2022)
         Enrolment: 2020-12-19 00:00:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
-    """kukkuu@example.com|['jennifer00@example.com']|Occurrence reminder FI|
+        Obsoleted: False''',
+    '''kukkuu@example.com|['jennifer00@example.com']|Occurrence reminder FI|
         Event FI: Special respond positive cold.
         Guardian FI: I Should Receive A Notification (jennifer00@example.com)
         Occurrence: 2020-12-13 00:00:00+00:00
         Child: Jason Williams (2021)
         Enrolment: 2020-12-13 00:00:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
+        Obsoleted: False'''
 ]
 
-snapshots[
-    "test_occurrence_reminder_notification[http://kultus-ui.test.kuva.hel.ninja/verify-ticket-endpoint/] 1"
-] = [
-    """kukkuu@example.com|['ywashington@example.com']|Occurrence reminder FI|
+snapshots['test_occurrence_reminder_notification[http://kultus-ui.test.kuva.hel.ninja/verify-ticket-endpoint/] 1'] = [
+    '''kukkuu@example.com|['ywashington@example.com']|Occurrence reminder FI|
         Event FI: Entire increase thank certainly again.
         Guardian FI: I Should Receive A Notification (ywashington@example.com)
         Occurrence: 2020-12-19 00:00:00+00:00
         Child: Jose Kerr (2022)
         Enrolment: 2020-12-19 00:00:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
-    """kukkuu@example.com|['jennifer00@example.com']|Occurrence reminder FI|
+        Obsoleted: False''',
+    '''kukkuu@example.com|['jennifer00@example.com']|Occurrence reminder FI|
         Event FI: Special respond positive cold.
         Guardian FI: I Should Receive A Notification (jennifer00@example.com)
         Occurrence: 2020-12-13 00:00:00+00:00
         Child: Jason Williams (2021)
         Enrolment: 2020-12-13 00:00:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
+        Obsoleted: False'''
 ]
 
-snapshots["test_reminder_notification_instance_checks[False] 1"] = []
+snapshots['test_reminder_notification_instance_checks[False] 1'] = [
+]
 
-snapshots["test_reminder_notification_instance_checks[True] 1"] = [
-    """kukkuu@example.com|['ywashington@example.com']|Occurrence reminder FI|
+snapshots['test_reminder_notification_instance_checks[True] 1'] = [
+    '''kukkuu@example.com|['ywashington@example.com']|Occurrence reminder FI|
         Event FI: Increase thank certainly again thought summer.
         Guardian FI: Denise Thompson (ywashington@example.com)
         Occurrence: 2020-12-04 00:00:00+00:00
         Child: Jose Kerr (2022)
         Enrolment: 2020-12-04 00:00:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
-    """kukkuu@example.com|['jennifer00@example.com']|Occurrence reminder FI|
+        Obsoleted: False''',
+    '''kukkuu@example.com|['jennifer00@example.com']|Occurrence reminder FI|
         Event FI: Special respond positive cold.
         Guardian FI: Danielle Reese (jennifer00@example.com)
         Occurrence: 2020-12-11 00:00:00+00:00
         Child: Jason Williams (2021)
         Enrolment: 2020-12-11 00:00:00+00:00
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False""",
+        Obsoleted: False'''
 ]
 
-snapshots["test_unenrol_occurrence_notification 1"] = [
-    """kukkuu@example.com|['pjenkins@example.net']|Occurrence unenrolment FI|
+snapshots['test_unenrol_occurrence_notification 1'] = [
+    '''kukkuu@example.com|['pjenkins@example.net']|Occurrence unenrolment FI|
         Event FI: Detail audience campaign college career fight data.
         Guardian FI: Calvin Gutierrez (pjenkins@example.net)
         Occurrence: 2020-12-12 00:00:00+00:00
         Child: Sandra Brown (2023)
         Unsubscribe: http://localhost:3000/fi/profile/subscriptions?authToken=a1b2c3d4e5f6g7h8
-        Obsoleted: False"""
+        Obsoleted: False'''
 ]

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -93,7 +93,6 @@ from kukkuu.consts import (
 )
 from kukkuu.exceptions import EnrolmentReferenceIdDoesNotExist
 from kukkuu.views import SentryGraphQLView
-from projects.factories import ProjectFactory
 from projects.models import Project
 from subscriptions.factories import FreeSpotNotificationSubscriptionFactory
 from users.factories import GuardianFactory, UserFactory
@@ -1438,14 +1437,13 @@ def test_update_field_with_null_value(project_user_api_client, project):
     assert "cannot be null" in str(executed["errors"])
 
 
-def test_child_enrol_occurence_from_different_project(
-    snapshot, guardian_api_client, child_with_user_guardian, occurrence
+def test_child_enrol_occurrence_from_different_project(
+    snapshot, guardian_api_client, child_with_user_guardian, occurrence, another_project
 ):
-    next_project = ProjectFactory(year=2021)
     another_occurrence = OccurrenceFactory(
-        event__project=next_project,
+        event__project=another_project,
         event__published_at=timezone.now(),
-        venue__project=next_project,
+        venue__project=another_project,
     )
     assert Occurrence.objects.count() == 2
     enrolment_variables = deepcopy(ENROL_OCCURRENCE_VARIABLES)

--- a/importers/tests/test_notification_importer.py
+++ b/importers/tests/test_notification_importer.py
@@ -35,8 +35,7 @@ def event_published_notification():
         create_notification_template_in_language(
             NotificationType.EVENT_PUBLISHED,
             language,
-            subject=f"{NotificationType.EVENT_PUBLISHED} "
-            f"{language} original subject",
+            subject=f"{NotificationType.EVENT_PUBLISHED} {language} original subject",
             body_text=f"{NotificationType.EVENT_PUBLISHED} "
             f"{language} original body_text",
         )

--- a/projects/consts.py
+++ b/projects/consts.py
@@ -1,9 +1,12 @@
+# Data taken from production Kukkuu API at
+# https://kukkuu.api.hel.fi/admin/projects/project/
 (
     PROJECT_DATA_2020,
     PROJECT_DATA_2021,
     PROJECT_DATA_2022,
     PROJECT_DATA_2023,
     PROJECT_DATA_2024,
+    PROJECT_DATA_2025,
 ) = PROJECTS_DATA = [
     {
         "year": 2020,
@@ -77,6 +80,27 @@
             "en": "Helsinki City Library and Helsinki City Sports Services",
             "fi": "Helsingin kirjasto- ja liikuntapalvelut",
             "sv": "Helsingfors biblioteks– och idrottstjänster",
+        },
+    },
+    {
+        "year": 2025,
+        "translations": {
+            "en": (
+                "HAM Helsinki Art Museum, Amos Rex, Sointi Jazz Orchestra, "
+                "UMO Helsinki Jazz Orchestra, Ateneum Art Museum, "
+                "Museum of Contemporary Art Kiasma and Sinebrychoff Art Museum"
+            ),
+            "fi": (
+                "HAM Helsingin taidemuseo, Amos Rex, Sointi Jazz Orchestra, "
+                "UMO Helsinki Jazz Orchestra ja Kansallisgalleria: "
+                "Ateneumin taidemuseo, Nykytaiteen museo Kiasma "
+                "ja Sinebrychoffin taidemuseo"
+            ),
+            "sv": (
+                "HAM Helsingfors konstmuseum, Amos Rex, Sointi Jazz Orchestra, "
+                "UMO Helsinki Jazz Orchestra och Nationalgalleriet dvs. Ateneum, "
+                "Kiasma och Konstmuseet Sinebrychoff"
+            ),
         },
     },
 ]

--- a/projects/consts.py
+++ b/projects/consts.py
@@ -1,0 +1,82 @@
+(
+    PROJECT_DATA_2020,
+    PROJECT_DATA_2021,
+    PROJECT_DATA_2022,
+    PROJECT_DATA_2023,
+    PROJECT_DATA_2024,
+) = PROJECTS_DATA = [
+    {
+        "year": 2020,
+        "translations": {
+            "en": "Helsinki Philharmonic Orchestra",
+            "fi": "Helsingin kaupunginorkesteri",
+            "sv": "Helsingfors stadsorkester",
+        },
+    },
+    {
+        "year": 2021,
+        "translations": {
+            "en": (
+                "Helsinki City Theatre, Finnish National Theatre, Svenska Teatern, "
+                "Theatre ILMI Ö., Q-teatteri and Puppet Theatre Sampo"
+            ),
+            "fi": (
+                "Helsingin Kaupunginteatteri, Suomen Kansallisteatteri, "
+                "Svenska Teatern, Teatteri ILMI Ö., Q-teatteri ja Nukketeatteri Sampo"
+            ),
+            "sv": (
+                "Helsingfors Stadsteater, Finlands Nationalteater, Svenska Teatern, "
+                "Teatteri ILMI Ö., Q-teatteri och Dockteatern Sampo"
+            ),
+        },
+    },
+    {
+        "year": 2022,
+        "translations": {
+            "en": (
+                "Cirko – Center for New Circus, Hotel and Restaurant Museum, "
+                "Finnish Museum of Photography, Dance House Helsinki, "
+                "Dance Theatre Hurjaruuth and Theatre Museum"
+            ),
+            "fi": (
+                "Cirko - uuden sirkuksen keskus, Hotelli- ja ravintolamuseo, "
+                "Suomen valokuvataiteen museo, Tanssin talo, "
+                "Tanssiteatteri Hurjaruuth ja Teatterimuseo"
+            ),
+            "sv": (
+                "Cirko - Centrumet för nycirkus, Hotell- och restaurangmuseet, "
+                "Dansens hus Helsingfors, Finlands fotografiska museum, "
+                "Dansteatern Hurjaruuth och Teatermuseet"
+            ),
+        },
+    },
+    {
+        "year": 2023,
+        "translations": {
+            "en": (
+                "Museum of Finnish Architecture, Design Museum, "
+                "Helsinki City Museum, National Museum of Finland, "
+                "Association of Cultural Heritage Education in Finland "
+                "and Helsinki University Museum Flame"
+            ),
+            "fi": (
+                "Arkkitehtuurimuseo, Designmuseo, Helsingin kaupunginmuseo, "
+                "Suomen kansallismuseo, Suomen kulttuuriperintökasvatuksen seura "
+                "ja Tiedemuseo Liekki"
+            ),
+            "sv": (
+                "Finlands Arkitekturmuseum, Designmuseet, Helsingfors stadsmuseum, "
+                "Finlands Nationalmuseum, Föreningen för kulturarvsfostran i Finland "
+                "och Vetenskapsmuseet Lågan"
+            ),
+        },
+    },
+    {
+        "year": 2024,
+        "translations": {
+            "en": "Helsinki City Library and Helsinki City Sports Services",
+            "fi": "Helsingin kirjasto- ja liikuntapalvelut",
+            "sv": "Helsingfors biblioteks– och idrottstjänster",
+        },
+    },
+]

--- a/projects/management/commands/load_project_data.py
+++ b/projects/management/commands/load_project_data.py
@@ -1,0 +1,29 @@
+from auditlog.context import disable_auditlog
+from django.apps import apps
+from django.core.management.base import BaseCommand
+
+from projects.consts import PROJECTS_DATA
+
+
+class Command(BaseCommand):
+    help = (
+        "Load default project data into the database. "
+        "There should be a project for each year after year 2020, "
+        "so the children who have that birth year can be enrolled in the project. "
+        "Each project is created or updated with translations. "
+    )
+
+    def handle(self, *args, **kwargs):
+        Project = apps.get_model("projects", "Project")
+
+        with disable_auditlog():
+            for project_data in PROJECTS_DATA:
+                project, created = Project.objects.get_or_create(
+                    year=project_data["year"]
+                )
+                for lang_code, name in project_data["translations"].items():
+                    project.set_current_language(lang_code)
+                    project.name = name
+                    project.save()
+
+        self.stdout.write(self.style.SUCCESS("Successfully loaded project data"))

--- a/projects/migrations/0009_add_projects_data.py
+++ b/projects/migrations/0009_add_projects_data.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+from django.core.management import call_command
+
+def load_project_data(apps, schema_editor):
+    call_command('load_project_data')
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0008_add_messaging_permission'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_project_data),
+    ]

--- a/projects/models.py
+++ b/projects/models.py
@@ -83,7 +83,8 @@ class Project(TranslatableModel, SerializableMixin):
         return [codename for codename, _ in cls._meta.permissions]
 
     def __str__(self):
-        return f"{self.name} {self.year}".strip()
+        name = self.safe_translation_getter("name", any_language=True)
+        return f"{name} {self.year}".strip()
 
     def can_user_administer(self, user):
         return user.can_administer_project(self)

--- a/projects/tests/snapshots/snap_test_api.py
+++ b/projects/tests/snapshots/snap_test_api.py
@@ -143,6 +143,29 @@ snapshots['test_projects_query_normal_user 1'] = {
                         ],
                         'year': 2024
                     }
+                },
+                {
+                    'node': {
+                        'enrolmentLimit': 2,
+                        'id': 'UHJvamVjdE5vZGU6Ng==',
+                        'name': 'HAM Helsingin taidemuseo, Amos Rex, Sointi Jazz Orchestra, UMO Helsinki Jazz Orchestra ja Kansallisgalleria: Ateneumin taidemuseo, Nykytaiteen museo Kiasma ja Sinebrychoffin taidemuseo',
+                        'singleEventsAllowed': True,
+                        'translations': [
+                            {
+                                'languageCode': 'EN',
+                                'name': 'HAM Helsinki Art Museum, Amos Rex, Sointi Jazz Orchestra, UMO Helsinki Jazz Orchestra, Ateneum Art Museum, Museum of Contemporary Art Kiasma and Sinebrychoff Art Museum'
+                            },
+                            {
+                                'languageCode': 'FI',
+                                'name': 'HAM Helsingin taidemuseo, Amos Rex, Sointi Jazz Orchestra, UMO Helsinki Jazz Orchestra ja Kansallisgalleria: Ateneumin taidemuseo, Nykytaiteen museo Kiasma ja Sinebrychoffin taidemuseo'
+                            },
+                            {
+                                'languageCode': 'SV',
+                                'name': 'HAM Helsingfors konstmuseum, Amos Rex, Sointi Jazz Orchestra, UMO Helsinki Jazz Orchestra och Nationalgalleriet dvs. Ateneum, Kiasma och Konstmuseet Sinebrychoff'
+                            }
+                        ],
+                        'year': 2025
+                    }
                 }
             ]
         }

--- a/projects/tests/snapshots/snap_test_api.py
+++ b/projects/tests/snapshots/snap_test_api.py
@@ -33,15 +33,115 @@ snapshots['test_projects_query_normal_user 1'] = {
                     'node': {
                         'enrolmentLimit': 2,
                         'id': 'UHJvamVjdE5vZGU6MQ==',
-                        'name': 'Testiprojekti',
+                        'name': 'Helsingin kaupunginorkesteri',
                         'singleEventsAllowed': True,
                         'translations': [
                             {
                                 'languageCode': 'FI',
-                                'name': 'Testiprojekti'
+                                'name': 'Helsingin kaupunginorkesteri'
+                            },
+                            {
+                                'languageCode': 'SV',
+                                'name': 'Helsingfors stadsorkester'
+                            },
+                            {
+                                'languageCode': 'EN',
+                                'name': 'Helsinki Philharmonic Orchestra'
                             }
                         ],
                         'year': 2020
+                    }
+                },
+                {
+                    'node': {
+                        'enrolmentLimit': 2,
+                        'id': 'UHJvamVjdE5vZGU6Mg==',
+                        'name': 'Helsingin Kaupunginteatteri, Suomen Kansallisteatteri, Svenska Teatern, Teatteri ILMI Ö., Q-teatteri ja Nukketeatteri Sampo',
+                        'singleEventsAllowed': True,
+                        'translations': [
+                            {
+                                'languageCode': 'EN',
+                                'name': 'Helsinki City Theatre, Finnish National Theatre, Svenska Teatern, Theatre ILMI Ö., Q-teatteri and Puppet Theatre Sampo'
+                            },
+                            {
+                                'languageCode': 'FI',
+                                'name': 'Helsingin Kaupunginteatteri, Suomen Kansallisteatteri, Svenska Teatern, Teatteri ILMI Ö., Q-teatteri ja Nukketeatteri Sampo'
+                            },
+                            {
+                                'languageCode': 'SV',
+                                'name': 'Helsingfors Stadsteater, Finlands Nationalteater, Svenska Teatern, Teatteri ILMI Ö., Q-teatteri och Dockteatern Sampo'
+                            }
+                        ],
+                        'year': 2021
+                    }
+                },
+                {
+                    'node': {
+                        'enrolmentLimit': 2,
+                        'id': 'UHJvamVjdE5vZGU6Mw==',
+                        'name': 'Cirko - uuden sirkuksen keskus, Hotelli- ja ravintolamuseo, Suomen valokuvataiteen museo, Tanssin talo, Tanssiteatteri Hurjaruuth ja Teatterimuseo',
+                        'singleEventsAllowed': True,
+                        'translations': [
+                            {
+                                'languageCode': 'EN',
+                                'name': 'Cirko – Center for New Circus, Hotel and Restaurant Museum, Finnish Museum of Photography, Dance House Helsinki, Dance Theatre Hurjaruuth and Theatre Museum'
+                            },
+                            {
+                                'languageCode': 'FI',
+                                'name': 'Cirko - uuden sirkuksen keskus, Hotelli- ja ravintolamuseo, Suomen valokuvataiteen museo, Tanssin talo, Tanssiteatteri Hurjaruuth ja Teatterimuseo'
+                            },
+                            {
+                                'languageCode': 'SV',
+                                'name': 'Cirko - Centrumet för nycirkus, Hotell- och restaurangmuseet, Dansens hus Helsingfors, Finlands fotografiska museum, Dansteatern Hurjaruuth och Teatermuseet'
+                            }
+                        ],
+                        'year': 2022
+                    }
+                },
+                {
+                    'node': {
+                        'enrolmentLimit': 2,
+                        'id': 'UHJvamVjdE5vZGU6NA==',
+                        'name': 'Arkkitehtuurimuseo, Designmuseo, Helsingin kaupunginmuseo, Suomen kansallismuseo, Suomen kulttuuriperintökasvatuksen seura ja Tiedemuseo Liekki',
+                        'singleEventsAllowed': True,
+                        'translations': [
+                            {
+                                'languageCode': 'EN',
+                                'name': 'Museum of Finnish Architecture, Design Museum, Helsinki City Museum, National Museum of Finland, Association of Cultural Heritage Education in Finland and Helsinki University Museum Flame'
+                            },
+                            {
+                                'languageCode': 'FI',
+                                'name': 'Arkkitehtuurimuseo, Designmuseo, Helsingin kaupunginmuseo, Suomen kansallismuseo, Suomen kulttuuriperintökasvatuksen seura ja Tiedemuseo Liekki'
+                            },
+                            {
+                                'languageCode': 'SV',
+                                'name': 'Finlands Arkitekturmuseum, Designmuseet, Helsingfors stadsmuseum, Finlands Nationalmuseum, Föreningen för kulturarvsfostran i Finland och Vetenskapsmuseet Lågan'
+                            }
+                        ],
+                        'year': 2023
+                    }
+                },
+                {
+                    'node': {
+                        'enrolmentLimit': 2,
+                        'id': 'UHJvamVjdE5vZGU6NQ==',
+                        'name': 'Helsingin kirjasto- ja liikuntapalvelut',
+                        'singleEventsAllowed': True,
+                        'translations': [
+                            {
+                                'languageCode': 'EN',
+                                'name': 'Helsinki City Library and Helsinki City Sports Services'
+                            },
+                            {
+                                'languageCode': 'FI',
+                                'name': 'Helsingin kirjasto- ja liikuntapalvelut'
+                            },
+                            {
+                                'languageCode': 'SV',
+                                'name': 'Helsingfors biblioteks– och idrottstjänster'
+                            }
+                        ],
+                        'year': 2024
                     }
                 }
             ]

--- a/projects/tests/test_load_project_data.py
+++ b/projects/tests/test_load_project_data.py
@@ -1,0 +1,27 @@
+import pytest
+from django.core.management import call_command
+
+from projects.consts import PROJECTS_DATA
+from projects.models import Project
+
+
+@pytest.fixture
+def empty_project_table():
+    Project.objects.all().delete()
+
+
+@pytest.mark.django_db
+def test_load_project_data(empty_project_table):
+    # Ensure the database is empty before running the command
+    assert Project.objects.count() == 0
+
+    # Call the management command
+    call_command("load_project_data")
+
+    # Verify that the projects have been loaded correctly
+    for project_data in PROJECTS_DATA:
+        project = Project.objects.get(year=project_data["year"])
+        assert project.year == project_data["year"]
+        for lang_code, name in project_data["translations"].items():
+            project.set_current_language(lang_code)
+            assert project.name == name

--- a/reports/serializers.py
+++ b/reports/serializers.py
@@ -181,8 +181,7 @@ class OccurrenceSerializer(serializers.ModelSerializer):
     )
 
     attended_count = serializers.SerializerMethodField(
-        help_text="Count of how many children atteded "
-        "in this occurrence of an event."
+        help_text="Count of how many children atteded in this occurrence of an event."
     )
 
     capacity = serializers.SerializerMethodField(
@@ -321,7 +320,7 @@ class EventSerializer(serializers.ModelSerializer):
         "in this event's occurrences."
     )
     attended_count = serializers.SerializerMethodField(
-        help_text="Count of how many children atteded " "in this event's occurrences."
+        help_text="Count of how many children atteded in this event's occurrences."
     )
     capacity = serializers.SerializerMethodField(
         help_text="The total capacity of how many children can there participate "

--- a/subscriptions/schema.py
+++ b/subscriptions/schema.py
@@ -199,7 +199,7 @@ class UnsubscribeFromAllNotificationsMutation(graphene.relay.ClientIDMutation):
     def mutate_and_get_payload(cls, root, info, **kwargs):
         user = info.context.user
         user.unsubscribe_all_notification_subscriptions()
-        logger.info(f"User {user.uuid} unsubscribed from all notifications." "")
+        logger.info(f"User {user.uuid} unsubscribed from all notifications.")
         return UnsubscribeFromAllNotificationsMutation(
             guardian=user.guardian, unsubscribed=True
         )

--- a/users/tests/snapshots/snap_test_api.py
+++ b/users/tests/snapshots/snap_test_api.py
@@ -119,6 +119,56 @@ snapshots['test_my_admin_profile_project_admin[has_also_model_perm] 1'] = {
                                 'manageEventGroups': True,
                                 'publish': True
                             },
+                            'name': 'Helsingin Kaupunginteatteri, Suomen Kansallisteatteri, Svenska Teatern, Teatteri ILMI Ö., Q-teatteri ja Nukketeatteri Sampo'
+                        }
+                    },
+                    {
+                        'node': {
+                            'myPermissions': {
+                                'canSendToAllInProject': True,
+                                'manageEventGroups': True,
+                                'publish': True
+                            },
+                            'name': 'Cirko - uuden sirkuksen keskus, Hotelli- ja ravintolamuseo, Suomen valokuvataiteen museo, Tanssin talo, Tanssiteatteri Hurjaruuth ja Teatterimuseo'
+                        }
+                    },
+                    {
+                        'node': {
+                            'myPermissions': {
+                                'canSendToAllInProject': True,
+                                'manageEventGroups': True,
+                                'publish': True
+                            },
+                            'name': 'Arkkitehtuurimuseo, Designmuseo, Helsingin kaupunginmuseo, Suomen kansallismuseo, Suomen kulttuuriperintökasvatuksen seura ja Tiedemuseo Liekki'
+                        }
+                    },
+                    {
+                        'node': {
+                            'myPermissions': {
+                                'canSendToAllInProject': True,
+                                'manageEventGroups': True,
+                                'publish': True
+                            },
+                            'name': 'Helsingin kirjasto- ja liikuntapalvelut'
+                        }
+                    },
+                    {
+                        'node': {
+                            'myPermissions': {
+                                'canSendToAllInProject': True,
+                                'manageEventGroups': True,
+                                'publish': True
+                            },
+                            'name': 'project where no object perms'
+                        }
+                    },
+                    {
+                        'node': {
+                            'myPermissions': {
+                                'canSendToAllInProject': True,
+                                'manageEventGroups': True,
+                                'publish': True
+                            },
                             'name': 'project where base admin object perm but no other object perms'
                         }
                     },
@@ -130,16 +180,6 @@ snapshots['test_my_admin_profile_project_admin[has_also_model_perm] 1'] = {
                                 'publish': True
                             },
                             'name': 'project where base admin object perm and other object perms'
-                        }
-                    },
-                    {
-                        'node': {
-                            'myPermissions': {
-                                'canSendToAllInProject': True,
-                                'manageEventGroups': True,
-                                'publish': True
-                            },
-                            'name': 'project where no object perms'
                         }
                     }
                 ]

--- a/users/tests/snapshots/snap_test_api.py
+++ b/users/tests/snapshots/snap_test_api.py
@@ -159,6 +159,16 @@ snapshots['test_my_admin_profile_project_admin[has_also_model_perm] 1'] = {
                                 'manageEventGroups': True,
                                 'publish': True
                             },
+                            'name': 'HAM Helsingin taidemuseo, Amos Rex, Sointi Jazz Orchestra, UMO Helsinki Jazz Orchestra ja Kansallisgalleria: Ateneumin taidemuseo, Nykytaiteen museo Kiasma ja Sinebrychoffin taidemuseo'
+                        }
+                    },
+                    {
+                        'node': {
+                            'myPermissions': {
+                                'canSendToAllInProject': True,
+                                'manageEventGroups': True,
+                                'publish': True
+                            },
                             'name': 'project where no object perms'
                         }
                     },

--- a/users/tests/test_api.py
+++ b/users/tests/test_api.py
@@ -396,7 +396,7 @@ def test_my_admin_profile_unauthenticated(api_client):
 
 
 def test_my_admin_profile_normal_user(user_api_client):
-    ProjectFactory(year=2021, name="some project")
+    ProjectFactory(year=2031, name="some project")
     executed = user_api_client.execute(MY_ADMIN_PROFILE_QUERY)
     assert executed["data"]["myAdminProfile"]["projects"]["edges"] == []
 
@@ -408,10 +408,10 @@ def test_my_admin_profile_project_admin(
     snapshot, user_api_client, has_also_model_perms
 ):
     project_1 = ProjectFactory(
-        year=2021, name="project where base admin object perm but no other object perms"
+        year=2031, name="project where base admin object perm but no other object perms"
     )
     project_2 = ProjectFactory(
-        year=2022, name="project where base admin object perm and other object perms"
+        year=2032, name="project where base admin object perm and other object perms"
     )
     assign_perm(
         ProjectPermission.ADMIN.value, user_api_client.user, [project_1, project_2]


### PR DESCRIPTION
KK-1394.

Add a new data migration file that adds the missing mandatory projects, 1 per year after year 2020. When children are added to the system, they always needs to be linked to a year project of their birth year.

Update the tests, because the new data migration will add more projects to the database and some of the tests were trusting in 1 specific state.

Fix the Project model `__str__` with a safe translation getter, since the management command has not set any language by default.