### PR TITLE
KK-1379 | Add Node.js to requirements because of pre-commit hook's doctoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Prerequisites:
 
 - PostgreSQL 13
 - Python 3.11
+- Node.js 20 or newer **ONLY** for using pre-commit hook's `doctoc`
 
 #### Installing Python requirements
 


### PR DESCRIPTION
## Description

Add Node.js to requirements because of pre-commit hook's doctoc

## Related

[KK-1379](https://helsinkisolutionoffice.atlassian.net/browse/KK-1379)
