### PR TITLE
feat(sentry): setup before_send to ignore global id errors by message

### DIFF
--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -167,9 +167,17 @@ def sentry_before_send(event: Event, hint: Hint):
     """
 
     IGNORED_ERRORS_CLASSES = (ExpiredSignatureError, AuthenticationExpiredError)
+    IGNORED_ERROR_MESSAGES = [
+        # This is raised when an id in URL or form input does not match.
+        # It is easily triggered by the user when URL is modified
+        # and does not need to be reported.
+        "Unable to parse global ID",
+    ]
     if "exc_info" in hint:
         exc_type, exc_value, traceback = hint["exc_info"]
         if isinstance(exc_value, IGNORED_ERRORS_CLASSES):
+            return None
+        if any(msg in str(exc_value) for msg in IGNORED_ERROR_MESSAGES):
             return None
     return event
 

--- a/kukkuu/tests/test_sentry.py
+++ b/kukkuu/tests/test_sentry.py
@@ -5,6 +5,8 @@ from kukkuu.exceptions import AuthenticationExpiredError
 from kukkuu.settings import sentry_before_send
 
 test_cases = [
+    (Exception("Unable to parse global ID."), True),
+    (Exception('Unable to parse global ID "some_id".'), True),
     (ExpiredSignatureError("Expired signature"), True),
     (AuthenticationExpiredError("Authentication expired"), True),
     (Exception("Some other error"), False),


### PR DESCRIPTION
KK-1395.

The ignore_messages option in sentry_sdk would be great, but since the Graphene raises a general Exception from invalid global ids, we need to follow the exception message instead of class.