### PR TITLE
feat(sentry): ignore authentication expired errors in Sentry

### DIFF
--- a/kukkuu/tests/test_sentry.py
+++ b/kukkuu/tests/test_sentry.py
@@ -1,0 +1,27 @@
+import pytest
+from jose import ExpiredSignatureError
+
+from kukkuu.exceptions import AuthenticationExpiredError
+from kukkuu.settings import sentry_before_send
+
+test_cases = [
+    (ExpiredSignatureError("Expired signature"), True),
+    (AuthenticationExpiredError("Authentication expired"), True),
+    (Exception("Some other error"), False),
+]
+
+
+@pytest.mark.parametrize(
+    "exception,should_return_none",
+    test_cases,
+)
+def test_sentry_before_send_ignores_defined_exceptions(exception, should_return_none):
+    hint = {"exc_info": (type(exception), exception, None)}
+    event = {"something": "test event is returned when not ignored"}
+
+    result = sentry_before_send(event, hint)
+
+    if should_return_none:
+        assert result is None  # Ensure the event is dropped
+    else:
+        assert result is not None  # Ensure the event is not dropped


### PR DESCRIPTION
KK-1396.

Sentry should ignore errors related to expired authentications, since it
is not a system error, but a feature related to JWT usage.

NOTE: https://github.com/City-of-Helsinki/kukkuu/pull/461 was created first, but later rebased to this.