### PR TITLE
KK-1409 | Fix django-admin logout

### DIFF
--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -6,7 +6,6 @@ import environ
 import sentry_sdk
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
-from helusers.defaults import SOCIAL_AUTH_PIPELINE  # noqa: F401
 from jose import ExpiredSignatureError
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.types import Event, Hint


### PR DESCRIPTION
## Description

## Fix django-admin logout by not importing helusers SOCIAL_AUTH_PIPELINE

With `from helusers.defaults import SOCIAL_AUTH_PIPELINE  # noqa: F401`
the post logout redirect uri was /helauth/logout/complete/ which didn't
match the /admin/ value given in the service integration document and
configured to Keycloak.

Updating the service integration document and configuring Keycloak to
use the post logout redirect uri of /helauth/logout/complete/ would also
fix this problem, and would log out the user from the AD also AFAIK.

Removing `from helusers.defaults import SOCIAL_AUTH_PIPELINE` makes the
post logout redirect uri match /admin/ i.e. the value configured to
Keycloak, and fixes logout from django-admin. A side effect of this is
that the user is not logged out from the AD.

## Related

[KK-1409](https://helsinkisolutionoffice.atlassian.net/browse/KK-1409)

## Screenshots

Previously trying to log out of django-admin locally with the
`from helusers.defaults import SOCIAL_AUTH_PIPELINE  # noqa: F401` line
intact:
- At https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect/logout?id_token_hint=id-token-hint-value-removed-but-was-present-in-the-real-url&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8081%2Fhelauth%2Flogout%2Fcomplete%2F when logging out
  - ![image](https://github.com/user-attachments/assets/70d14110-11af-4ab7-8529-304ed5044328)



[KK-1409]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ