### PR TITLE
docs: add mention to set secret from the keyvault

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Optionally if you want to use pre-commit hooks:
 
 ### Development with Docker
 
-1. Copy `docker-compose.env.example` to `docker-compose.env` and modify it if needed.
+1. Copy `docker-compose.env.example` to `docker-compose.env`, then modify it as needed. At a minimum, ensure that `SOCIAL_AUTH_TUNNISTAMO_SECRET` is set using the secret from keyvault.
 
 2. Run `docker compose up`
 


### PR DESCRIPTION
This update improves the README by adding instructions for setting up docker-compose.env. It guides users to copy the example file and configure SOCIAL_AUTH_SECRET with the appropriate secret from keyvault.

**Changes**:
- Updated README.md with setup instructions for docker-compose.env.

**Why**:
- Helps new developers quickly configure their environment.
- Ensures proper setup of authentication secrets.