### PR TITLE
KK-1422 | Use `helusers.defaults.SOCIAL_AUTH_PIPELINE` to deduplicate users

### DIFF
--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -6,6 +6,7 @@ import environ
 import sentry_sdk
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
+from helusers.defaults import SOCIAL_AUTH_PIPELINE  # noqa: F401
 from jose import ExpiredSignatureError
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.types import Event, Hint


### PR DESCRIPTION
## Description

Django-admin Keycloak login related fix:

Revert 2d14cbe34119a8fbce8216ea8f838724ae9a92b1 which caused bug
https://helsinkisolutionoffice.atlassian.net/browse/KK-1422 i.e.
"AD-login to django-admin & kukkuu-admin UI with same AD user creates
two different users in backend".

Needs updating of post logout redirect URIs at Keycloak from /admin/ to
/helauth/logout/complete/, updated the post logout redirect URIs to
Kukkuu's service integration document:
https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/8679030785/Palveluintegraatio+HP+-+Kukkuu+Kulttuurin+kummilapset

Asked Solution Office (i.e. Ratkaisutoimisto) on 2025-03-04 to
update the post logout redirect URIs to Keycloak.

## Related

[KK-1422](https://helsinkisolutionoffice.atlassian.net/browse/KK-1422)

[KK-1422]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ