### PR TITLE
KK-1422 | Fix logout by upgrading deps to latest, incl. django-helusers v0.13.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     # the ruff's version line, it is used by test_pre_commit_ruff_version.py
     # test case in order not to have to add a YAML library dependency just
     # to test this version:
-    rev: v0.9.9 # ruff-pre-commit version
+    rev: v0.9.10 # ruff-pre-commit version
     hooks:
       # Run the linter
       - id: ruff

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,7 +38,7 @@ idna==3.10
     #   requests
 iniconfig==2.0.0
     # via pytest
-ipython==9.0.1
+ipython==9.0.2
     # via -r requirements-dev.in
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -96,7 +96,7 @@ requests-mock==1.12.1
     # via -r requirements-dev.in
 responses==0.25.6
     # via -r requirements-dev.in
-ruff==0.9.9
+ruff==0.9.10
     # via -r requirements-dev.in
 six==1.17.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,7 @@ django-guardian==2.4.0
     # via -r requirements.in
 django-health-check==3.18.3
     # via -r requirements.in
-django-helusers==0.13.2
+django-helusers==0.13.3
     # via
     #   -r requirements.in
     #   helsinki-profile-gdpr-api
@@ -118,7 +118,7 @@ ecdsa==0.19.0
     # via python-jose
 factory-boy==3.3.3
     # via -r requirements.in
-faker==36.2.2
+faker==37.0.0
     # via factory-boy
 graphene==3.4.3
     # via


### PR DESCRIPTION
## Description

### Fix logout by upgrading deps to latest, incl. django-helusers v0.13.3

logout got broken in 53dde1146834c96395c603fe03bd5973b4ead8f1

django-helusers fixed logout in City-of-Helsinki/django-helusers#114
which was released in django-helusers v0.13.3

refs KK-1422

## Related

- [KK-1422](https://helsinkisolutionoffice.atlassian.net/browse/KK-1422)
- https://github.com/City-of-Helsinki/django-helusers/releases/tag/django-helusers-v0.13.3
- https://github.com/City-of-Helsinki/django-helusers/pull/114

[KK-1422]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ