### PR TITLE
feat: transition to structured (json) logging

### DIFF
--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -305,6 +305,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "auditlog_extra.middleware.AuditlogMiddleware",
+    "logger_extra.middleware.XRequestIdMiddleware",
 ]
 
 TEMPLATES = [

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -288,6 +288,7 @@ INSTALLED_APPS = [
     "reports",
     "verification_tokens",
     "auditlog_extra",
+    "logger_extra",
     "kukkuu",
     "django_cleanup.apps.CleanupConfig",  # This must be included last
 ]
@@ -499,13 +500,22 @@ SPECTACULAR_SETTINGS = {"TITLE": "Kukkuu report API", "VERSION": "1.0.0"}
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        "context": {
+            "()": "logger_extra.filter.LoggerContextFilter",
+        }
+    },
     "formatters": {
-        "timestamped_named": {
-            "format": "%(asctime)s %(name)s %(levelname)s: %(message)s"
+        "json": {
+            "()": "logger_extra.formatter.JSONFormatter",
         }
     },
     "handlers": {
-        "console": {"class": "logging.StreamHandler", "formatter": "timestamped_named"}
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "json",
+            "filters": ["context"],
+        }
     },
     "loggers": {
         "": {

--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -483,6 +483,7 @@ if KUKKUU_HASHID_SALT is None:
         "Hashids in Kukkuu utils requires the setting!"
     )
 
+LOGGER_EXTRA_AUGMENT_DJANGO_AUDITLOG = True
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [

--- a/requirements.in
+++ b/requirements.in
@@ -29,4 +29,4 @@ requests
 sentry-sdk
 social-auth-app-django
 django-auditlog-extra@git+https://github.com/City-of-Helsinki/django-auditlog-extra.git@bff5fa3921d6821bebdd6be6c9fd20db39d32d54#egg=django-auditlog-extra
-django-logger-extra@git+https://github.com/City-of-Helsinki/django-logger-extra.git@main
+django-logger-extra@https://github.com/City-of-Helsinki/django-logger-extra/archive/refs/tags/v0.1.0.zip

--- a/requirements.in
+++ b/requirements.in
@@ -29,3 +29,4 @@ requests
 sentry-sdk
 social-auth-app-django
 django-auditlog-extra@git+https://github.com/City-of-Helsinki/django-auditlog-extra.git@bff5fa3921d6821bebdd6be6c9fd20db39d32d54#egg=django-auditlog-extra
+django-logger-extra@git+https://github.com/City-of-Helsinki/django-logger-extra.git@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,7 +97,7 @@ django-helusers==0.13.3
     #   helsinki-profile-gdpr-api
 django-ilmoitin==0.7.1
     # via -r requirements.in
-django-logger-extra @ git+https://github.com/City-of-Helsinki/django-logger-extra.git@main
+django-logger-extra @ https://github.com/City-of-Helsinki/django-logger-extra/archive/refs/tags/v0.1.0.zip
     # via -r requirements.in
 django-mailer==2.3.2
     # via django-ilmoitin

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,6 +57,7 @@ django==4.2.21
     #   django-health-check
     #   django-helusers
     #   django-ilmoitin
+    #   django-logger-extra
     #   django-mailer
     #   django-parler
     #   django-storages
@@ -95,6 +96,8 @@ django-helusers==0.13.3
     #   -r requirements.in
     #   helsinki-profile-gdpr-api
 django-ilmoitin==0.7.1
+    # via -r requirements.in
+django-logger-extra @ git+https://github.com/City-of-Helsinki/django-logger-extra.git@main
     # via -r requirements.in
 django-mailer==2.3.2
     # via django-ilmoitin


### PR DESCRIPTION
DRAFT:

KK-1442

Kukkuu is using formatted, but non-structured logging. Transition to JSON logging by making use of the `django-logger-extra` (https://github.com/City-of-Helsinki/django-logger-extra) library.

Also make request id as part of the logger context and pass it also to the django-auditlog as additional_data property.
The request id is read from the incoming header `X-Request-ID` or if it's not present, generated using UUID v4.