### PR TITLE
Add notification templates in code repository in HTML format

### DIFF
--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -474,8 +474,12 @@ KUKKUU_FEEDBACK_NOTIFICATION_DELAY = env("KUKKUU_FEEDBACK_NOTIFICATION_DELAY")
 # If set to 0, unenrolment is allowed till the occurrence start.
 KUKKUU_ENROLMENT_UNENROL_HOURS_BEFORE = env("KUKKUU_ENROLMENT_UNENROL_HOURS_BEFORE")
 NOTIFICATIONS_IMPORTER = (
-    "notification_importers.notification_importer.NotificationGoogleSheetImporter"
+    # To use project repository filesystem as a source, use the following:
+    "notification_importers.notification_importer.NotificationFileImporter"
+    # To use Google Spreadsheet as a source, use the following:
+    # "notification_importers.notification_importer.NotificationGoogleSheetImporter"
 )
+# NOTIFICATIONS_SHEET_ID only needed with NotificationGoogleSheetImporter
 NOTIFICATIONS_SHEET_ID = env("KUKKUU_NOTIFICATIONS_SHEET_ID")
 
 KUKKUU_HASHID_MIN_LENGTH = 5

--- a/notification_importers/templates/email/event_group_published-en.html
+++ b/notification_importers/templates/email/event_group_published-en.html
@@ -14,5 +14,4 @@ The Culture Kids programme is arranged by the City of Helsinki Culture and Leisu
 https://kummilapset.hel.fi
 kulttuurin.kummilapset@hel.fi
 
-{% if is_obsolete %} This message has been sent to the email address of a deactivated Culture Kid profile. If you have already re-registered your child on our website https://kummilapset.hel.fi, please unsubscribe from receiving emails for the deactivated profile here {{unsubscribe_url}}.
-{% else %} I no longer want to receive email about the publication of events: {{unsubscribe_url}} {% endif %}
+I no longer want to receive email about the publication of events: {{unsubscribe_url}}.

--- a/notification_importers/templates/email/event_group_published-en.html
+++ b/notification_importers/templates/email/event_group_published-en.html
@@ -1,0 +1,18 @@
+Greetings Culture Kid!
+
+{{ event_group.description }}
+
+Sign up and read more in our service
+{{ event_group_url }}
+
+
+Culture Kids
+Culture Kids is a programme that pairs children living in Helsinki with a sponsor from the world of arts and culture. All of the city’s little ones born in or after 2020 are invited to join. The Culture Kids sponsor invites the children and a member of their family to at least two events every year. The events support children’s development and promote the wellbeing of the entire family. The sponsorship continues until the child starts primary school.
+All events are free-of-charge for the children participating in the programme.
+The Culture Kids programme is arranged by the City of Helsinki Culture and Leisure Division.
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi
+
+{% if is_obsolete %} This message has been sent to the email address of a deactivated Culture Kid profile. If you have already re-registered your child on our website https://kummilapset.hel.fi, please unsubscribe from receiving emails for the deactivated profile here {{unsubscribe_url}}.
+{% else %} I no longer want to receive email about the publication of events: {{unsubscribe_url}} {% endif %}

--- a/notification_importers/templates/email/event_group_published-en.html
+++ b/notification_importers/templates/email/event_group_published-en.html
@@ -11,7 +11,7 @@
 
     <p>
       Sign up and read more in our service:
-      <a href="{{ event_group_url }}">{{ event_group_url }}</a>
+      <a href="{{ event_group_url }}">Sign up</a>
     </p>
 
     <h2>Culture Kids</h2>
@@ -36,7 +36,7 @@
 
     <p>
       I no longer want to receive email about the publication of events:
-      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+      <a href="{{unsubscribe_url}}">Unsubscribe</a>
     </p>
   </body>
 </html>

--- a/notification_importers/templates/email/event_group_published-en.html
+++ b/notification_importers/templates/email/event_group_published-en.html
@@ -1,17 +1,42 @@
-Greetings Culture Kid!
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>An invitation for Culture Kid!</title>
+  </head>
+  <body>
+    <h1>Greetings Culture Kid!</h1>
 
-{{ event_group.description }}
+    <p>{{ event_group.description }}</p>
 
-Sign up and read more in our service
-{{ event_group_url }}
+    <p>
+      Sign up and read more in our service:
+      <a href="{{ event_group_url }}">{{ event_group_url }}</a>
+    </p>
 
+    <h2>Culture Kids</h2>
+    <p>
+      Culture Kids is a programme that pairs children living in Helsinki with a
+      sponsor from the world of arts and culture. All of the city's little ones
+      born in or after 2020 are invited to join. The Culture Kids sponsor
+      invites the children and a member of their family to at least two events
+      every year. The events support children's development and promote the
+      wellbeing of the entire family. The sponsorship continues until the child
+      starts primary school. All events are free-of-charge for the children
+      participating in the programme. The Culture Kids programme is arranged by
+      the City of Helsinki Culture and Leisure Division.
+    </p>
 
-Culture Kids
-Culture Kids is a programme that pairs children living in Helsinki with a sponsor from the world of arts and culture. All of the city’s little ones born in or after 2020 are invited to join. The Culture Kids sponsor invites the children and a member of their family to at least two events every year. The events support children’s development and promote the wellbeing of the entire family. The sponsorship continues until the child starts primary school.
-All events are free-of-charge for the children participating in the programme.
-The Culture Kids programme is arranged by the City of Helsinki Culture and Leisure Division.
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
 
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
-
-I no longer want to receive email about the publication of events: {{unsubscribe_url}}.
+    <p>
+      I no longer want to receive email about the publication of events:
+      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+    </p>
+  </body>
+</html>

--- a/notification_importers/templates/email/event_group_published-fi.html
+++ b/notification_importers/templates/email/event_group_published-fi.html
@@ -1,0 +1,20 @@
+Hei Kulttuurin kummilapsi!
+
+{{ event_group.description }}
+
+Ilmoittaudu ja lue lisää osoitteessa
+{{ event_group_url }}
+
+
+Kulttuurin kummilapset
+Jokaisella vuonna 2020 tai sen jälkeen syntyvällä helsinkiläisellä lapsella on oma kulttuurikummi.
+Kulttuurikummi kutsuu lapsen joka vuosi vähintään kahteen tapahtumaan. Tapahtumat suunnitellaan lapsen kehitysvaiheelle sopiviksi ja ne tukevat koko perheen hyvinvointia. Kummius jatkuu siihen asti, kunnes lapsi aloittaa koulun.
+Tapahtumat ovat perheille maksuttomia.
+Kulttuurin kummilapset -palvelua hallinnoi Helsingin kulttuurin ja vapaa-ajan toimiala.
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi
+
+
+{% if is_obsolete %} Tämä viesti on lähetetty käytöstä poistetun kummilapsiprofiilin sähköpostiosoitteeseen. Jos olet jo rekisteröinyt lapsesi uudestaan verkkosivuillamme https://kummilapset.hel.fi, peru käytöstä poistetun profiilin sähköpostiviestit tästä {{unsubscribe_url}}.
+{% else %} En halua enää viestejä kummitapahtumien julkaisusta: {{unsubscribe_url}} {% endif %}

--- a/notification_importers/templates/email/event_group_published-fi.html
+++ b/notification_importers/templates/email/event_group_published-fi.html
@@ -16,5 +16,4 @@ https://kummilapset.hel.fi
 kulttuurin.kummilapset@hel.fi
 
 
-{% if is_obsolete %} Tämä viesti on lähetetty käytöstä poistetun kummilapsiprofiilin sähköpostiosoitteeseen. Jos olet jo rekisteröinyt lapsesi uudestaan verkkosivuillamme https://kummilapset.hel.fi, peru käytöstä poistetun profiilin sähköpostiviestit tästä {{unsubscribe_url}}.
-{% else %} En halua enää viestejä kummitapahtumien julkaisusta: {{unsubscribe_url}} {% endif %}
+En halua enää viestejä kummitapahtumien julkaisusta: {{unsubscribe_url}}.

--- a/notification_importers/templates/email/event_group_published-fi.html
+++ b/notification_importers/templates/email/event_group_published-fi.html
@@ -11,7 +11,7 @@
 
     <p>
       Ilmoittaudu ja lue lisää osoitteessa:
-      <a href="{{ event_group_url }}">{{ event_group_url }}</a>
+      <a href="{{ event_group_url }}">Ilmoittautuminen</a>
     </p>
 
     <h2>Kulttuurin kummilapset</h2>
@@ -34,7 +34,7 @@
 
     <p>
       En halua enää viestejä kummitapahtumien julkaisusta:
-      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+      <a href="{{unsubscribe_url}}">Peruuta viestien tilaus</a>
     </p>
   </body>
 </html>

--- a/notification_importers/templates/email/event_group_published-fi.html
+++ b/notification_importers/templates/email/event_group_published-fi.html
@@ -1,19 +1,40 @@
-Hei Kulttuurin kummilapsi!
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Kutsu kulttuurin kummilapselle!</title>
+  </head>
+  <body>
+    <h1>Hei Kulttuurin kummilapsi!</h1>
 
-{{ event_group.description }}
+    <p>{{ event_group.description }}</p>
 
-Ilmoittaudu ja lue lisää osoitteessa
-{{ event_group_url }}
+    <p>
+      Ilmoittaudu ja lue lisää osoitteessa:
+      <a href="{{ event_group_url }}">{{ event_group_url }}</a>
+    </p>
 
+    <h2>Kulttuurin kummilapset</h2>
+    <p>
+      Jokaisella vuonna 2020 tai sen jälkeen syntyvällä helsinkiläisellä
+      lapsella on oma kulttuurikummi. Kulttuurikummi kutsuu lapsen joka vuosi
+      vähintään kahteen tapahtumaan. Tapahtumat suunnitellaan lapsen
+      kehitysvaiheelle sopiviksi ja ne tukevat koko perheen hyvinvointia.
+      Kummius jatkuu siihen asti, kunnes lapsi aloittaa koulun. Tapahtumat ovat
+      perheille maksuttomia. Kulttuurin kummilapset -palvelua hallinnoi
+      Helsingin kulttuurin ja vapaa-ajan toimiala.
+    </p>
 
-Kulttuurin kummilapset
-Jokaisella vuonna 2020 tai sen jälkeen syntyvällä helsinkiläisellä lapsella on oma kulttuurikummi.
-Kulttuurikummi kutsuu lapsen joka vuosi vähintään kahteen tapahtumaan. Tapahtumat suunnitellaan lapsen kehitysvaiheelle sopiviksi ja ne tukevat koko perheen hyvinvointia. Kummius jatkuu siihen asti, kunnes lapsi aloittaa koulun.
-Tapahtumat ovat perheille maksuttomia.
-Kulttuurin kummilapset -palvelua hallinnoi Helsingin kulttuurin ja vapaa-ajan toimiala.
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
 
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
-
-
-En halua enää viestejä kummitapahtumien julkaisusta: {{unsubscribe_url}}.
+    <p>
+      En halua enää viestejä kummitapahtumien julkaisusta:
+      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+    </p>
+  </body>
+</html>

--- a/notification_importers/templates/email/event_group_published-sv.html
+++ b/notification_importers/templates/email/event_group_published-sv.html
@@ -11,7 +11,7 @@
 
     <p>
       Anmäl dig och läs mer på:
-      <a href="{{ event_group_url }}">{{ event_group_url }}</a>
+      <a href="{{ event_group_url }}">Anmäl dig</a>
     </p>
 
     <h2>Kulturens fadderbarn</h2>
@@ -34,7 +34,7 @@
 
     <p>
       Jag vill inte ha några fler meddelanden om publicering av evenemang:
-      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+      <a href="{{unsubscribe_url}}">Avsluta prenumerationen</a>
     </p>
   </body>
 </html>

--- a/notification_importers/templates/email/event_group_published-sv.html
+++ b/notification_importers/templates/email/event_group_published-sv.html
@@ -14,5 +14,4 @@ Tjänsten Kulturens fadderbarn förvaltas av Kultur- och fritidssektorn i Helsin
 https://kummilapset.hel.fi
 kulttuurin.kummilapset@hel.fi
 
-{% if is_obsolete %} Detta meddelande har skickats till e-postadressen för en fadderbarnsprofil som inte längre är i bruk. Om du redan har registrerat barnet på nytt på vår webbplats  https://kummilapset.hel.fi, och inte längre vill få e-postmeddelanden för den profil som inte längre är i bruk, klicka här {{unsubscribe_url}}.
-{% else %} Jag vill inte ha några fler meddelanden om publicering av evenemang: {{unsubscribe_url}} {% endif %}
+Jag vill inte ha några fler meddelanden om publicering av evenemang: {{unsubscribe_url}}.

--- a/notification_importers/templates/email/event_group_published-sv.html
+++ b/notification_importers/templates/email/event_group_published-sv.html
@@ -1,0 +1,18 @@
+Bästa Kulturens fadderbarn!
+
+{{ event_group.description }}
+
+Anmäl dig och läs mer på
+{{ event_group_url }}
+
+
+Kulturens fadderbarn
+Alla barn i Helsingfors som är födda 2020 och därefter har en egen kulturfadder. Kulturfaddern bjuder in barnet till minst två evenemang per år. Evenemangen planeras så att de passar barnets utvecklingsnivå, och de stöder hela familjens välmående. Fadderskapet fortsätter tills barnet börjar skolan.
+Evenemangen är avgiftsfria för familjerna.
+Tjänsten Kulturens fadderbarn förvaltas av Kultur- och fritidssektorn i Helsingfors stad.
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi
+
+{% if is_obsolete %} Detta meddelande har skickats till e-postadressen för en fadderbarnsprofil som inte längre är i bruk. Om du redan har registrerat barnet på nytt på vår webbplats  https://kummilapset.hel.fi, och inte längre vill få e-postmeddelanden för den profil som inte längre är i bruk, klicka här {{unsubscribe_url}}.
+{% else %} Jag vill inte ha några fler meddelanden om publicering av evenemang: {{unsubscribe_url}} {% endif %}

--- a/notification_importers/templates/email/event_group_published-sv.html
+++ b/notification_importers/templates/email/event_group_published-sv.html
@@ -1,17 +1,40 @@
-Bästa Kulturens fadderbarn!
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <title>Inbjudan för Kulturens fadderbarn!</title>
+  </head>
+  <body>
+    <h1>Bästa Kulturens fadderbarn!</h1>
 
-{{ event_group.description }}
+    <p>{{ event_group.description }}</p>
 
-Anmäl dig och läs mer på
-{{ event_group_url }}
+    <p>
+      Anmäl dig och läs mer på:
+      <a href="{{ event_group_url }}">{{ event_group_url }}</a>
+    </p>
 
+    <h2>Kulturens fadderbarn</h2>
+    <p>
+      Alla barn i Helsingfors som är födda 2020 och därefter har en egen
+      kulturfadder. Kulturfaddern bjuder in barnet till minst två evenemang per
+      år. Evenemangen planeras så att de passar barnets utvecklingsnivå, och de
+      stöder hela familjens välmående. Fadderskapet fortsätter tills barnet
+      börjar skolan. Evenemangen är avgiftsfria för familjerna. Tjänsten
+      Kulturens fadderbarn förvaltas av Kultur- och fritidssektorn i Helsingfors
+      stad.
+    </p>
 
-Kulturens fadderbarn
-Alla barn i Helsingfors som är födda 2020 och därefter har en egen kulturfadder. Kulturfaddern bjuder in barnet till minst två evenemang per år. Evenemangen planeras så att de passar barnets utvecklingsnivå, och de stöder hela familjens välmående. Fadderskapet fortsätter tills barnet börjar skolan.
-Evenemangen är avgiftsfria för familjerna.
-Tjänsten Kulturens fadderbarn förvaltas av Kultur- och fritidssektorn i Helsingfors stad.
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
 
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
-
-Jag vill inte ha några fler meddelanden om publicering av evenemang: {{unsubscribe_url}}.
+    <p>
+      Jag vill inte ha några fler meddelanden om publicering av evenemang:
+      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+    </p>
+  </body>
+</html>

--- a/notification_importers/templates/email/event_published-en.html
+++ b/notification_importers/templates/email/event_published-en.html
@@ -1,17 +1,42 @@
-Greetings, Culture Kid!
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Invitation for Culture Kid!</title>
+  </head>
+  <body>
+    <h1>Greetings, Culture Kid!</h1>
 
-{{ event.description }}
+    <p>{{ event.description }}</p>
 
-Sign up in our service
-{{ event_url }}
+    <p>
+      Sign up in our service:
+      <a href="{{ event_url }}">{{ event_url }}</a>
+    </p>
 
+    <h2>Culture Kids</h2>
+    <p>
+      Culture Kids is a programme that pairs children living in Helsinki with a
+      sponsor from the world of arts and culture. All of the city's little ones
+      born in or after 2020 are invited to join. The Culture Kids sponsor
+      invites the children and a member of their family to at least two events
+      every year. The events support children's development and promote the
+      wellbeing of the entire family. The sponsorship continues until the child
+      starts primary school. All events are free-of-charge for the children
+      participating in the programme. The Culture Kids programme is arranged by
+      the City of Helsinki Culture and Leisure Division.
+    </p>
 
-Culture Kids
-Culture Kids is a programme that pairs children living in Helsinki with a sponsor from the world of arts and culture. All of the city’s little ones born in or after 2020 are invited to join. The Culture Kids sponsor invites the children and a member of their family to at least two events every year. The events support children’s development and promote the wellbeing of the entire family. The sponsorship continues until the child starts primary school.
-All events are free-of-charge for the children participating in the programme.
-The Culture Kids programme is arranged by the City of Helsinki Culture and Leisure Division.
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
 
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
-
-I no longer want to receive email about the publication of events: {{unsubscribe_url}}.
+    <p>
+      I no longer want to receive email about the publication of events:
+      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+    </p>
+  </body>
+</html>

--- a/notification_importers/templates/email/event_published-en.html
+++ b/notification_importers/templates/email/event_published-en.html
@@ -1,0 +1,18 @@
+Greetings, Culture Kid!
+
+{{ event.description }}
+
+Sign up in our service
+{{ event_url }}
+
+
+Culture Kids
+Culture Kids is a programme that pairs children living in Helsinki with a sponsor from the world of arts and culture. All of the city’s little ones born in or after 2020 are invited to join. The Culture Kids sponsor invites the children and a member of their family to at least two events every year. The events support children’s development and promote the wellbeing of the entire family. The sponsorship continues until the child starts primary school.
+All events are free-of-charge for the children participating in the programme.
+The Culture Kids programme is arranged by the City of Helsinki Culture and Leisure Division.
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi
+
+{% if is_obsolete %} This message has been sent to the email address of a deactivated Culture Kid profile. If you have already re-registered your child on our website https://kummilapset.hel.fi, please unsubscribe from receiving emails for the deactivated profile here {{unsubscribe_url}}.
+{% else %} I no longer want to receive email about the publication of events: {{unsubscribe_url}} {% endif %}

--- a/notification_importers/templates/email/event_published-en.html
+++ b/notification_importers/templates/email/event_published-en.html
@@ -14,5 +14,4 @@ The Culture Kids programme is arranged by the City of Helsinki Culture and Leisu
 https://kummilapset.hel.fi
 kulttuurin.kummilapset@hel.fi
 
-{% if is_obsolete %} This message has been sent to the email address of a deactivated Culture Kid profile. If you have already re-registered your child on our website https://kummilapset.hel.fi, please unsubscribe from receiving emails for the deactivated profile here {{unsubscribe_url}}.
-{% else %} I no longer want to receive email about the publication of events: {{unsubscribe_url}} {% endif %}
+I no longer want to receive email about the publication of events: {{unsubscribe_url}}.

--- a/notification_importers/templates/email/event_published-en.html
+++ b/notification_importers/templates/email/event_published-en.html
@@ -11,7 +11,7 @@
 
     <p>
       Sign up in our service:
-      <a href="{{ event_url }}">{{ event_url }}</a>
+      <a href="{{ event_url }}">Sign up</a>
     </p>
 
     <h2>Culture Kids</h2>
@@ -36,7 +36,7 @@
 
     <p>
       I no longer want to receive email about the publication of events:
-      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+      <a href="{{unsubscribe_url}}">Unsubscribe</a>
     </p>
   </body>
 </html>

--- a/notification_importers/templates/email/event_published-fi.html
+++ b/notification_importers/templates/email/event_published-fi.html
@@ -10,8 +10,8 @@
     <p>{{ event.description }}</p>
 
     <p>
-      Ilmoittaudu osoitteessa:
-      <a href="{{ event_url }}">{{ event_url }}</a>
+      Ilmoittaudu tästä:
+      <a href="{{ event_url }}">Ilmoittaudu</a>
     </p>
 
     <h2>Kulttuurin kummilapset</h2>
@@ -34,7 +34,7 @@
 
     <p>
       En halua enää viestejä kummitapahtumien julkaisusta:
-      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+      <a href="{{unsubscribe_url}}">Peruuta viestien tilaus</a>
     </p>
   </body>
 </html>

--- a/notification_importers/templates/email/event_published-fi.html
+++ b/notification_importers/templates/email/event_published-fi.html
@@ -1,0 +1,19 @@
+Hei Kulttuurin kummilapsi!
+
+{{ event.description }}
+
+Ilmoittaudu osoitteessa
+{{ event_url }}
+
+
+Kulttuurin kummilapset
+Jokaisella vuonna 2020 tai sen jälkeen syntyvällä helsinkiläisellä lapsella on oma kulttuurikummi.
+Kulttuurikummi kutsuu lapsen joka vuosi vähintään kahteen tapahtumaan. Tapahtumat suunnitellaan lapsen kehitysvaiheelle sopiviksi ja ne tukevat koko perheen hyvinvointia. Kummius jatkuu siihen asti, kunnes lapsi aloittaa koulun.
+Tapahtumat ovat perheille maksuttomia.
+Kulttuurin kummilapset -palvelua hallinnoi Helsingin kulttuurin ja vapaa-ajan toimiala.
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi
+
+{% if is_obsolete %} Tämä viesti on lähetetty käytöstä poistetun kummilapsiprofiilin sähköpostiosoitteeseen. Jos olet jo rekisteröinyt lapsesi uudestaan verkkosivuillamme https://kummilapset.hel.fi, peru käytöstä poistetun profiilin sähköpostiviestit tästä {{unsubscribe_url}}.
+{% else %} En halua enää viestejä kummitapahtumien julkaisusta: {{unsubscribe_url}} {% endif %}

--- a/notification_importers/templates/email/event_published-fi.html
+++ b/notification_importers/templates/email/event_published-fi.html
@@ -15,5 +15,4 @@ Kulttuurin kummilapset -palvelua hallinnoi Helsingin kulttuurin ja vapaa-ajan to
 https://kummilapset.hel.fi
 kulttuurin.kummilapset@hel.fi
 
-{% if is_obsolete %} Tämä viesti on lähetetty käytöstä poistetun kummilapsiprofiilin sähköpostiosoitteeseen. Jos olet jo rekisteröinyt lapsesi uudestaan verkkosivuillamme https://kummilapset.hel.fi, peru käytöstä poistetun profiilin sähköpostiviestit tästä {{unsubscribe_url}}.
-{% else %} En halua enää viestejä kummitapahtumien julkaisusta: {{unsubscribe_url}} {% endif %}
+En halua enää viestejä kummitapahtumien julkaisusta: {{unsubscribe_url}}.

--- a/notification_importers/templates/email/event_published-fi.html
+++ b/notification_importers/templates/email/event_published-fi.html
@@ -1,18 +1,40 @@
-Hei Kulttuurin kummilapsi!
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Kutsu kulttuurin kummilapselle!</title>
+  </head>
+  <body>
+    <h1>Hei Kulttuurin kummilapsi!</h1>
 
-{{ event.description }}
+    <p>{{ event.description }}</p>
 
-Ilmoittaudu osoitteessa
-{{ event_url }}
+    <p>
+      Ilmoittaudu osoitteessa:
+      <a href="{{ event_url }}">{{ event_url }}</a>
+    </p>
 
+    <h2>Kulttuurin kummilapset</h2>
+    <p>
+      Jokaisella vuonna 2020 tai sen jälkeen syntyvällä helsinkiläisellä
+      lapsella on oma kulttuurikummi. Kulttuurikummi kutsuu lapsen joka vuosi
+      vähintään kahteen tapahtumaan. Tapahtumat suunnitellaan lapsen
+      kehitysvaiheelle sopiviksi ja ne tukevat koko perheen hyvinvointia.
+      Kummius jatkuu siihen asti, kunnes lapsi aloittaa koulun. Tapahtumat ovat
+      perheille maksuttomia. Kulttuurin kummilapset -palvelua hallinnoi
+      Helsingin kulttuurin ja vapaa-ajan toimiala.
+    </p>
 
-Kulttuurin kummilapset
-Jokaisella vuonna 2020 tai sen jälkeen syntyvällä helsinkiläisellä lapsella on oma kulttuurikummi.
-Kulttuurikummi kutsuu lapsen joka vuosi vähintään kahteen tapahtumaan. Tapahtumat suunnitellaan lapsen kehitysvaiheelle sopiviksi ja ne tukevat koko perheen hyvinvointia. Kummius jatkuu siihen asti, kunnes lapsi aloittaa koulun.
-Tapahtumat ovat perheille maksuttomia.
-Kulttuurin kummilapset -palvelua hallinnoi Helsingin kulttuurin ja vapaa-ajan toimiala.
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
 
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
-
-En halua enää viestejä kummitapahtumien julkaisusta: {{unsubscribe_url}}.
+    <p>
+      En halua enää viestejä kummitapahtumien julkaisusta:
+      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+    </p>
+  </body>
+</html>

--- a/notification_importers/templates/email/event_published-sv.html
+++ b/notification_importers/templates/email/event_published-sv.html
@@ -1,0 +1,19 @@
+Bästa Kulturens fadderbarn!
+
+{{ event.description }}
+
+Anmäl dig på
+{{ event_url }}
+
+
+Kulturens fadderbarn
+Alla barn i Helsingfors som är födda 2020 och därefter har en egen kulturfadder. Kulturfaddern bjuder in barnet till minst två evenemang per år. Evenemangen planeras så att de passar barnets utvecklingsnivå, och de stöder hela familjens välmående. Fadderskapet fortsätter tills barnet börjar skolan.
+Evenemangen är avgiftsfria för familjerna.
+Tjänsten Kulturens fadderbarn förvaltas av Kultur- och fritidssektorn i Helsingfors stad.
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi
+
+{% if is_obsolete %} Detta meddelande har skickats till e-postadressen för en fadderbarnsprofil som inte längre är i bruk. Om du redan har registrerat barnet på nytt på vår webbplats  https://kummilapset.hel.fi, och inte längre vill få e-postmeddelanden för den profil som inte längre är i bruk, klicka här {{unsubscribe_url}}.
+{% else %} Jag vill inte ha några fler meddelanden om publicering av evenemang: {{unsubscribe_url}} {% endif %}

--- a/notification_importers/templates/email/event_published-sv.html
+++ b/notification_importers/templates/email/event_published-sv.html
@@ -1,18 +1,40 @@
-Bästa Kulturens fadderbarn!
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <title>Inbjudan för Kulturens fadderbarn!</title>
+  </head>
+  <body>
+    <h1>Bästa Kulturens fadderbarn!</h1>
 
-{{ event.description }}
+    <p>{{ event.description }}</p>
 
-Anmäl dig på
-{{ event_url }}
+    <p>
+      Anmäl dig på:
+      <a href="{{ event_url }}">{{ event_url }}</a>
+    </p>
 
+    <h2>Kulturens fadderbarn</h2>
+    <p>
+      Alla barn i Helsingfors som är födda 2020 och därefter har en egen
+      kulturfadder. Kulturfaddern bjuder in barnet till minst två evenemang per
+      år. Evenemangen planeras så att de passar barnets utvecklingsnivå, och de
+      stöder hela familjens välmående. Fadderskapet fortsätter tills barnet
+      börjar skolan. Evenemangen är avgiftsfria för familjerna. Tjänsten
+      Kulturens fadderbarn förvaltas av Kultur- och fritidssektorn i Helsingfors
+      stad.
+    </p>
 
-Kulturens fadderbarn
-Alla barn i Helsingfors som är födda 2020 och därefter har en egen kulturfadder. Kulturfaddern bjuder in barnet till minst två evenemang per år. Evenemangen planeras så att de passar barnets utvecklingsnivå, och de stöder hela familjens välmående. Fadderskapet fortsätter tills barnet börjar skolan.
-Evenemangen är avgiftsfria för familjerna.
-Tjänsten Kulturens fadderbarn förvaltas av Kultur- och fritidssektorn i Helsingfors stad.
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
-
-Jag vill inte ha några fler meddelanden om publicering av evenemang: {{unsubscribe_url}}.
+    <p>
+      Jag vill inte längre få e-post om publiceringen av evenemang:
+      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+    </p>
+  </body>
+</html>

--- a/notification_importers/templates/email/event_published-sv.html
+++ b/notification_importers/templates/email/event_published-sv.html
@@ -15,5 +15,4 @@ Tjänsten Kulturens fadderbarn förvaltas av Kultur- och fritidssektorn i Helsin
 https://kummilapset.hel.fi
 kulttuurin.kummilapset@hel.fi
 
-{% if is_obsolete %} Detta meddelande har skickats till e-postadressen för en fadderbarnsprofil som inte längre är i bruk. Om du redan har registrerat barnet på nytt på vår webbplats  https://kummilapset.hel.fi, och inte längre vill få e-postmeddelanden för den profil som inte längre är i bruk, klicka här {{unsubscribe_url}}.
-{% else %} Jag vill inte ha några fler meddelanden om publicering av evenemang: {{unsubscribe_url}} {% endif %}
+Jag vill inte ha några fler meddelanden om publicering av evenemang: {{unsubscribe_url}}.

--- a/notification_importers/templates/email/event_published-sv.html
+++ b/notification_importers/templates/email/event_published-sv.html
@@ -11,7 +11,7 @@
 
     <p>
       Anmäl dig på:
-      <a href="{{ event_url }}">{{ event_url }}</a>
+      <a href="{{ event_url }}">Anmäl dig</a>
     </p>
 
     <h2>Kulturens fadderbarn</h2>
@@ -34,7 +34,7 @@
 
     <p>
       Jag vill inte längre få e-post om publiceringen av evenemang:
-      <a href="{{unsubscribe_url}}">{{unsubscribe_url}}</a>
+      <a href="{{unsubscribe_url}}">Avsluta prenumerationen</a>
     </p>
   </body>
 </html>

--- a/notification_importers/templates/email/free_spot-en.html
+++ b/notification_importers/templates/email/free_spot-en.html
@@ -1,10 +1,31 @@
-A place in {{ event.name }} {{ localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }} has become available.
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Place available: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      A place in {{ event.name }} {{
+      localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }} has become
+      available.
+    </p>
 
-Sign up at
-{{ occurrence_enrol_url }}
+    <p>
+      Sign up at:
+      <a href="{{ occurrence_enrol_url }}">{{ occurrence_enrol_url }}</a>
+    </p>
 
-Everyone subscribed for this notification will be informed as soon as a place becomes available. Free places will go for those who sign up first.
+    <p>
+      Everyone subscribed for this notification will be informed as soon as a
+      place becomes available. Free places will go for those who sign up first.
+    </p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/free_spot-en.html
+++ b/notification_importers/templates/email/free_spot-en.html
@@ -1,0 +1,10 @@
+A place in {{ event.name }} {{ localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }} has become available.
+
+Sign up at
+{{ occurrence_enrol_url }}
+
+Everyone subscribed for this notification will be informed as soon as a place becomes available. Free places will go for those who sign up first.
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/free_spot-en.html
+++ b/notification_importers/templates/email/free_spot-en.html
@@ -13,7 +13,7 @@
 
     <p>
       Sign up at:
-      <a href="{{ occurrence_enrol_url }}">{{ occurrence_enrol_url }}</a>
+      <a href="{{ occurrence_enrol_url }}">Sign up</a>
     </p>
 
     <p>

--- a/notification_importers/templates/email/free_spot-fi.html
+++ b/notification_importers/templates/email/free_spot-fi.html
@@ -1,10 +1,32 @@
-Tapahtumaan {{ event.name }} {{ localtime(occurrence.time).strftime('%d.%m.%Y klo %H.%M') }} on vapautunut paikka.
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Paikka vapautunut: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      Tapahtumaan {{ event.name }} {{
+      localtime(occurrence.time).strftime('%d.%m.%Y klo %H.%M') }} on vapautunut
+      paikka.
+    </p>
 
-Ilmoittaudu osoitteessa
-{{ occurrence_enrol_url }}
+    <p>
+      Ilmoittaudu osoitteessa:
+      <a href="{{ occurrence_enrol_url }}">{{ occurrence_enrol_url }}</a>
+    </p>
 
-Lähetämme tiedon vapautuneesta paikasta kaikille, jotka ovat tilanneet tämän ilmoituksen ja vapaat paikat menevät tapahtumaan ensimmäiseksi ilmoittautuville.
+    <p>
+      Lähetämme tiedon vapautuneesta paikasta kaikille, jotka ovat tilanneet
+      tämän ilmoituksen ja vapaat paikat menevät tapahtumaan ensimmäiseksi
+      ilmoittautuville.
+    </p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/free_spot-fi.html
+++ b/notification_importers/templates/email/free_spot-fi.html
@@ -12,8 +12,8 @@
     </p>
 
     <p>
-      Ilmoittaudu osoitteessa:
-      <a href="{{ occurrence_enrol_url }}">{{ occurrence_enrol_url }}</a>
+      Ilmoittaudu tästä:
+      <a href="{{ occurrence_enrol_url }}">Ilmoittaudu</a>
     </p>
 
     <p>

--- a/notification_importers/templates/email/free_spot-fi.html
+++ b/notification_importers/templates/email/free_spot-fi.html
@@ -1,0 +1,10 @@
+Tapahtumaan {{ event.name }} {{ localtime(occurrence.time).strftime('%d.%m.%Y klo %H.%M') }} on vapautunut paikka.
+
+Ilmoittaudu osoitteessa
+{{ occurrence_enrol_url }}
+
+Lähetämme tiedon vapautuneesta paikasta kaikille, jotka ovat tilanneet tämän ilmoituksen ja vapaat paikat menevät tapahtumaan ensimmäiseksi ilmoittautuville.
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/free_spot-sv.html
+++ b/notification_importers/templates/email/free_spot-sv.html
@@ -1,10 +1,31 @@
-En plats till {{ event.name }} {{ localtime(occurrence.time).strftime('%d.%m.%Y på %H.%M') }} har blivit ledig.
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <title>Plats frigjorts: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      En plats till {{ event.name }} {{
+      localtime(occurrence.time).strftime('%d.%m.%Y kl %H.%M') }} har blivit
+      ledig.
+    </p>
 
-Anmäl dig på
-{{ occurrence_enrol_url }}
+    <p>
+      Anmäl dig på:
+      <a href="{{ occurrence_enrol_url }}">{{ occurrence_enrol_url }}</a>
+    </p>
 
-Vi skickar info om den lediga platsen till alla som har prenumererar på anmälan. Lediga platser kommer att gå för dem som anmäler sig först.
+    <p>
+      Vi skickar info om den lediga platsen till alla som har prenumererar på
+      anmälan. Lediga platser kommer att gå för dem som anmäler sig först.
+    </p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/free_spot-sv.html
+++ b/notification_importers/templates/email/free_spot-sv.html
@@ -1,0 +1,10 @@
+En plats till {{ event.name }} {{ localtime(occurrence.time).strftime('%d.%m.%Y på %H.%M') }} har blivit ledig.
+
+Anmäl dig på
+{{ occurrence_enrol_url }}
+
+Vi skickar info om den lediga platsen till alla som har prenumererar på anmälan. Lediga platser kommer att gå för dem som anmäler sig först.
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/free_spot-sv.html
+++ b/notification_importers/templates/email/free_spot-sv.html
@@ -13,7 +13,7 @@
 
     <p>
       Anmäl dig på:
-      <a href="{{ occurrence_enrol_url }}">{{ occurrence_enrol_url }}</a>
+      <a href="{{ occurrence_enrol_url }}">Anmäl dig</a>
     </p>
 
     <p>

--- a/notification_importers/templates/email/guardian_email_change_token-en.html
+++ b/notification_importers/templates/email/guardian_email_change_token-en.html
@@ -1,0 +1,8 @@
+Verify your email address.
+
+You are about to change an email address in the Culture Kids -service. Please use the code below to verify your email address.
+
+If you do not want to change your email address in the Culture Kids, please ignore this message.
+
+Culture Kids verification code:
+{{verification_token}}

--- a/notification_importers/templates/email/guardian_email_change_token-en.html
+++ b/notification_importers/templates/email/guardian_email_change_token-en.html
@@ -1,8 +1,25 @@
-Verify your email address.
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Verify your email address</title>
+  </head>
+  <body>
+    <h1>Verify your email address</h1>
 
-You are about to change an email address in the Culture Kids -service. Please use the code below to verify your email address.
+    <p>
+      You are about to change an email address in the Culture Kids service.
+      Please use the code below to verify your email address.
+    </p>
 
-If you do not want to change your email address in the Culture Kids, please ignore this message.
+    <p>
+      If you do not want to change your email address in the Culture Kids,
+      please ignore this message.
+    </p>
 
-Culture Kids verification code:
-{{verification_token}}
+    <p>
+      <strong>Culture Kids verification code:</strong><br />
+      {{verification_token}}
+    </p>
+  </body>
+</html>

--- a/notification_importers/templates/email/guardian_email_change_token-fi.html
+++ b/notification_importers/templates/email/guardian_email_change_token-fi.html
@@ -1,0 +1,8 @@
+Vahvista sähköpostiosoitteesi.
+
+Olet vaihtamassa sähköpostiosoitetta Kulttuurin kummilapsiin. Käytä allaolevaa koodia vahvistaaksesi sähköpostiosoitteesi.
+
+Jos et ole vaihtamassa sähköpostiosoitetta Kulttuurin kummilapsiin, voit jättää tämän viestin huomioimatta.
+
+Kulttuurin kummilapsien vahvistuskoodi:
+{{verification_token}}

--- a/notification_importers/templates/email/guardian_email_change_token-fi.html
+++ b/notification_importers/templates/email/guardian_email_change_token-fi.html
@@ -1,8 +1,25 @@
-Vahvista sähköpostiosoitteesi.
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Vahvista sähköpostiosoitteesi</title>
+  </head>
+  <body>
+    <h1>Vahvista sähköpostiosoitteesi</h1>
 
-Olet vaihtamassa sähköpostiosoitetta Kulttuurin kummilapsiin. Käytä allaolevaa koodia vahvistaaksesi sähköpostiosoitteesi.
+    <p>
+      Olet vaihtamassa sähköpostiosoitetta Kulttuurin kummilapsiin. Käytä
+      allaolevaa koodia vahvistaaksesi sähköpostiosoitteesi.
+    </p>
 
-Jos et ole vaihtamassa sähköpostiosoitetta Kulttuurin kummilapsiin, voit jättää tämän viestin huomioimatta.
+    <p>
+      Jos et ole vaihtamassa sähköpostiosoitetta Kulttuurin kummilapsiin, voit
+      jättää tämän viestin huomioimatta.
+    </p>
 
-Kulttuurin kummilapsien vahvistuskoodi:
-{{verification_token}}
+    <p>
+      <strong>Kulttuurin kummilapsien vahvistuskoodi:</strong><br />
+      {{verification_token}}
+    </p>
+  </body>
+</html>

--- a/notification_importers/templates/email/guardian_email_change_token-sv.html
+++ b/notification_importers/templates/email/guardian_email_change_token-sv.html
@@ -1,0 +1,8 @@
+Verifiera din e-postadress.
+
+Du håller på att ändra en e-postadress i tjänsten Kulturens fadderbarn. Använd koden nedan för att verifiera din e-postadress.
+
+Om du inte vill ändra din e-postadress i Kulturens fadderbarn, vänligen ignorera detta meddelande.
+
+Kulturens fadderbarn verifieringskod:
+{{verification_token}}

--- a/notification_importers/templates/email/guardian_email_change_token-sv.html
+++ b/notification_importers/templates/email/guardian_email_change_token-sv.html
@@ -1,8 +1,25 @@
-Verifiera din e-postadress.
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <title>Bekräfta e-postadressen</title>
+  </head>
+  <body>
+    <h1>Verifiera din e-postadress</h1>
 
-Du håller på att ändra en e-postadress i tjänsten Kulturens fadderbarn. Använd koden nedan för att verifiera din e-postadress.
+    <p>
+      Du håller på att ändra en e-postadress i tjänsten Kulturens fadderbarn.
+      Använd koden nedan för att verifiera din e-postadress.
+    </p>
 
-Om du inte vill ändra din e-postadress i Kulturens fadderbarn, vänligen ignorera detta meddelande.
+    <p>
+      Om du inte vill ändra din e-postadress i Kulturens fadderbarn, vänligen
+      ignorera detta meddelande.
+    </p>
 
-Kulturens fadderbarn verifieringskod:
-{{verification_token}}
+    <p>
+      <strong>Kulturens fadderbarn verifieringskod:</strong><br />
+      {{verification_token}}
+    </p>
+  </body>
+</html>

--- a/notification_importers/templates/email/guardian_email_changed-en.html
+++ b/notification_importers/templates/email/guardian_email_changed-en.html
@@ -1,0 +1,5 @@
+You changed your email in the Culture Kids -service. You'll receive all the upcoming event invitations and other notifications to this address from now on.
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/guardian_email_changed-en.html
+++ b/notification_importers/templates/email/guardian_email_changed-en.html
@@ -1,5 +1,23 @@
-You changed your email in the Culture Kids -service. You'll receive all the upcoming event invitations and other notifications to this address from now on.
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>
+      Your email address has been changed in the Culture Kids -service
+    </title>
+  </head>
+  <body>
+    <p>
+      You changed your email in the Culture Kids service. You'll receive all the
+      upcoming event invitations and other notifications to this address from
+      now on.
+    </p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/guardian_email_changed-fi.html
+++ b/notification_importers/templates/email/guardian_email_changed-fi.html
@@ -1,5 +1,21 @@
-Vaihdoit sähköpostiosoitteesi Kulttuurin kummilapset -palvelussa. Jatkossa saat kaikki toimintaan liittyvät tapahtumakutsut ja muut ilmoitukset tähän osoitteeseen.
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sähköpostiosoite vaihdettu Kulttuurin kummilapset -palvelussa</title>
+  </head>
+  <body>
+    <p>
+      Vaihdoit sähköpostiosoitteesi Kulttuurin kummilapset -palvelussa. Jatkossa
+      saat kaikki toimintaan liittyvät tapahtumakutsut ja muut ilmoitukset tähän
+      osoitteeseen.
+    </p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/guardian_email_changed-fi.html
+++ b/notification_importers/templates/email/guardian_email_changed-fi.html
@@ -1,0 +1,5 @@
+Vaihdoit sähköpostiosoitteesi Kulttuurin kummilapset -palvelussa. Jatkossa saat kaikki toimintaan liittyvät tapahtumakutsut ja muut ilmoitukset tähän osoitteeseen.
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/guardian_email_changed-sv.html
+++ b/notification_importers/templates/email/guardian_email_changed-sv.html
@@ -1,0 +1,5 @@
+Du har ändrat din e-post i Kulturens fadderbarn -tjänsten. Från och med nu kommer du att få alla inbjudningar till evenemang och andra meddelanden till denna adress.
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/guardian_email_changed-sv.html
+++ b/notification_importers/templates/email/guardian_email_changed-sv.html
@@ -1,5 +1,21 @@
-Du har ändrat din e-post i Kulturens fadderbarn -tjänsten. Från och med nu kommer du att få alla inbjudningar till evenemang och andra meddelanden till denna adress.
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <title>E-postadress ändrad i Kulturens fadderbarn -tjänsten</title>
+  </head>
+  <body>
+    <p>
+      Du har ändrat din e-post i Kulturens fadderbarn-tjänsten. Från och med nu
+      kommer du att få alla inbjudningar till evenemang och andra meddelanden
+      till denna adress.
+    </p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_cancelled-en.html
+++ b/notification_importers/templates/email/occurrence_cancelled-en.html
@@ -1,0 +1,4 @@
+You have signed up for the {{ event.name }} scheduled for {{ localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }}. The event is unfortunately cancelled.  If there are still places available, you can register for another event on our website. We apologise for the inconvenience.
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_cancelled-en.html
+++ b/notification_importers/templates/email/occurrence_cancelled-en.html
@@ -1,4 +1,23 @@
-You have signed up for the {{ event.name }} scheduled for {{ localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }}. The event is unfortunately cancelled.  If there are still places available, you can register for another event on our website. We apologise for the inconvenience.
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Event cancellation: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      You have signed up for the {{ event.name }} scheduled for {{
+      localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }}. The event is
+      unfortunately cancelled. If there are still places available, you can
+      register for another event on our website. We apologise for the
+      inconvenience.
+    </p>
 
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_cancelled-fi.html
+++ b/notification_importers/templates/email/occurrence_cancelled-fi.html
@@ -1,4 +1,23 @@
-Olette ilmoittautuneet {{ localtime(occurrence.time).strftime('%d.%m.%Y klo %H.%M') }} järjestettävään tapahtumaan {{ event.name }}. Joudumme valitettavasti perumaan tapahtuman. Jos tapahtumissa on vielä tilaa, voitte ilmoittautua toiseen tapahtumaan sivustollamme. Pahoittelemme teille aiheutunutta vaivaa.
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Tapahtuman peruutus: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      Olette ilmoittautuneet {{ localtime(occurrence.time).strftime('%d.%m.%Y
+      klo %H.%M') }} järjestettävään tapahtumaan {{ event.name }}. Joudumme
+      valitettavasti perumaan tapahtuman. Jos tapahtumissa on vielä tilaa,
+      voitte ilmoittautua toiseen tapahtumaan sivustollamme. Pahoittelemme
+      teille aiheutunutta vaivaa.
+    </p>
 
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_cancelled-fi.html
+++ b/notification_importers/templates/email/occurrence_cancelled-fi.html
@@ -1,0 +1,4 @@
+Olette ilmoittautuneet {{ localtime(occurrence.time).strftime('%d.%m.%Y klo %H.%M') }} järjestettävään tapahtumaan {{ event.name }}. Joudumme valitettavasti perumaan tapahtuman. Jos tapahtumissa on vielä tilaa, voitte ilmoittautua toiseen tapahtumaan sivustollamme. Pahoittelemme teille aiheutunutta vaivaa.
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_cancelled-sv.html
+++ b/notification_importers/templates/email/occurrence_cancelled-sv.html
@@ -1,4 +1,23 @@
-Du har anmält dig till {{ event.name }} {{ localtime(occurrence.time).strftime('%d.%m.%Y på %H.%M') }}. Vi är tyvärr tvungna att ställa in evenemanget.  Om det fortfarande finns lediga platser vid evenemang kan du anmäla dig till ett annat evenemang på vår webbplats. Vi ber om ursäkt för eventuella besvär detta kan orsaka.
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <title>Avbokning av evenemanget: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      Du har anmält dig till {{ event.name }} {{
+      localtime(occurrence.time).strftime('%d.%m.%Y på %H.%M') }}. Vi är tyvärr
+      tvungna att ställa in evenemanget. Om det fortfarande finns lediga platser
+      vid evenemang kan du anmäla dig till ett annat evenemang på vår webbplats.
+      Vi ber om ursäkt för eventuella besvär detta kan orsaka.
+    </p>
 
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_cancelled-sv.html
+++ b/notification_importers/templates/email/occurrence_cancelled-sv.html
@@ -1,0 +1,4 @@
+Du har anmält dig till {{ event.name }} {{ localtime(occurrence.time).strftime('%d.%m.%Y på %H.%M') }}. Vi är tyvärr tvungna att ställa in evenemanget.  Om det fortfarande finns lediga platser vid evenemang kan du anmäla dig till ett annat evenemang på vår webbplats. Vi ber om ursäkt för eventuella besvär detta kan orsaka.
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_enrolment-en.html
+++ b/notification_importers/templates/email/occurrence_enrolment-en.html
@@ -1,0 +1,12 @@
+Thank you for signing up for {{ event.name }}, {{ localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }}. The venue is {{ occurrence.venue.name }} at {{ occurrence.venue.address }}, we are looking forward to seeing you there! You can find the information on your event by logging in to the Culture Kids service.
+
+Admission ticket
+Attached to this message is a QR code which is the ticket for the event. Take the QR code with you and show it when you arrive at the event.
+
+Cancellation of participation
+If you are unable to attend the event, please cancel your participation on the event page. From August 2025, you must cancel at least 48 hours before the event.
+{{ occurrence_url }}
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_enrolment-en.html
+++ b/notification_importers/templates/email/occurrence_enrolment-en.html
@@ -1,12 +1,37 @@
-Thank you for signing up for {{ event.name }}, {{ localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }}. The venue is {{ occurrence.venue.name }} at {{ occurrence.venue.address }}, we are looking forward to seeing you there! You can find the information on your event by logging in to the Culture Kids service.
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Confirmation for signing up for {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      Thank you for signing up for {{ event.name }}, {{
+      localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }}. The venue is
+      {{ occurrence.venue.name }} at {{ occurrence.venue.address }}, we are
+      looking forward to seeing you there! You can find the information on your
+      event by logging in to the Culture Kids service.
+    </p>
 
-Admission ticket
-Attached to this message is a QR code which is the ticket for the event. Take the QR code with you and show it when you arrive at the event.
+    <h2>Admission ticket</h2>
+    <p>
+      Attached to this message is a QR code which is the ticket for the event.
+      Take the QR code with you and show it when you arrive at the event.
+    </p>
 
-Cancellation of participation
-If you are unable to attend the event, please cancel your participation on the event page. From August 2025, you must cancel at least 48 hours before the event.
-{{ occurrence_url }}
+    <h2>Cancellation of participation</h2>
+    <p>
+      If you are unable to attend the event, please cancel your participation on
+      the event page. From August 2025, you must cancel at least 48 hours before
+      the event.<br />
+      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+    </p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_enrolment-en.html
+++ b/notification_importers/templates/email/occurrence_enrolment-en.html
@@ -24,7 +24,7 @@
       If you are unable to attend the event, please cancel your participation on
       the event page. From August 2025, you must cancel at least 48 hours before
       the event.<br />
-      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+      <a href="{{ occurrence_url }}">Cancel enrolment</a>.
     </p>
 
     <address>

--- a/notification_importers/templates/email/occurrence_enrolment-fi.html
+++ b/notification_importers/templates/email/occurrence_enrolment-fi.html
@@ -24,7 +24,7 @@
       Jos ette pääse osallistumaan tapahtumaan, peru osallistumisenne tapahtuman
       sivulla. Elokuusta 2025 alkaen sinun tulee perua viimeistään 48 tuntia
       ennen tapahtumaa.<br />
-      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+      <a href="{{ occurrence_url }}">Peruuta ilmoittauminen</a>
     </p>
 
     <address>

--- a/notification_importers/templates/email/occurrence_enrolment-fi.html
+++ b/notification_importers/templates/email/occurrence_enrolment-fi.html
@@ -1,12 +1,37 @@
-Kiitos ilmoittautumisestasi {{ localtime(occurrence.time).strftime('%d.%m.%Y klo %H.%M') }} järjestettävään tapahtumaan {{ event.name }}. Tapahtuman paikka on {{ occurrence.venue.name }}, {{ occurrence.venue.address }}, tervetuloa! Löydät tapahtumasi tiedot kirjautumalla Kulttuurin kummilapset -palveluun.
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Vahvistus ilmoittautumisestasi tapahtumaan {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      Kiitos ilmoittautumisestasi {{
+      localtime(occurrence.time).strftime('%d.%m.%Y klo %H.%M') }}
+      järjestettävään tapahtumaan {{ event.name }}. Tapahtuman paikka on {{
+      occurrence.venue.name }}, {{ occurrence.venue.address }}, tervetuloa!
+      Löydät tapahtumasi tiedot kirjautumalla Kulttuurin kummilapset -palveluun.
+    </p>
 
-Pääsylippu
-Tämän viestin liitteenä on QR-koodi, joka on tapahtuman pääsylippu. Ota QR-koodi mukaan ja näytä se, kun saavut tapahtumaan.
+    <h2>Pääsylippu</h2>
+    <p>
+      Tämän viestin liitteenä on QR-koodi, joka on tapahtuman pääsylippu. Ota
+      QR-koodi mukaan ja näytä se, kun saavut tapahtumaan.
+    </p>
 
-Osallistumisen peruminen
-Jos ette pääse osallistumaan tapahtumaan, peru osallistumisenne tapahtuman sivulla. Elokuusta 2025 alkaen sinun tulee perua viimeistään 48 tuntia ennen tapahtumaa.
-{{ occurrence_url }}
+    <h2>Osallistumisen peruminen</h2>
+    <p>
+      Jos ette pääse osallistumaan tapahtumaan, peru osallistumisenne tapahtuman
+      sivulla. Elokuusta 2025 alkaen sinun tulee perua viimeistään 48 tuntia
+      ennen tapahtumaa.<br />
+      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+    </p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_enrolment-fi.html
+++ b/notification_importers/templates/email/occurrence_enrolment-fi.html
@@ -1,0 +1,12 @@
+Kiitos ilmoittautumisestasi {{ localtime(occurrence.time).strftime('%d.%m.%Y klo %H.%M') }} järjestettävään tapahtumaan {{ event.name }}. Tapahtuman paikka on {{ occurrence.venue.name }}, {{ occurrence.venue.address }}, tervetuloa! Löydät tapahtumasi tiedot kirjautumalla Kulttuurin kummilapset -palveluun.
+
+Pääsylippu
+Tämän viestin liitteenä on QR-koodi, joka on tapahtuman pääsylippu. Ota QR-koodi mukaan ja näytä se, kun saavut tapahtumaan.
+
+Osallistumisen peruminen
+Jos ette pääse osallistumaan tapahtumaan, peru osallistumisenne tapahtuman sivulla. Elokuusta 2025 alkaen sinun tulee perua viimeistään 48 tuntia ennen tapahtumaa.
+{{ occurrence_url }}
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_enrolment-sv.html
+++ b/notification_importers/templates/email/occurrence_enrolment-sv.html
@@ -1,0 +1,12 @@
+Tack för din anmälan till {{ event.name }}, {{ localtime(occurrence.time).strftime('%d.%m.%Y på %H.%M') }}. Lokalen är {{ occurrence.venue.name }}, {{ occurrence.venue.address }}, välkomna! Du hittar uppgifterna om ditt evenemang genom att logga in på tjänsten Kulturens fadderbarn.
+
+Biljett till evenemanget
+Bifogat till detta meddelande finns en QR-kod som är biljetten till evenemanget. Ta med dig QR-koden och visa upp den när du kommer till evenemanget.
+
+Avbokning av deltagande
+Om du inte kan delta i evenemanget, vänligen avboka ditt deltagande på evenemangssidan. Från och med augusti 2025 måste du avboka senast 48 timmar före evenemanget.
+{{ occurrence_url }}
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_enrolment-sv.html
+++ b/notification_importers/templates/email/occurrence_enrolment-sv.html
@@ -25,7 +25,7 @@
       Om du inte kan delta i evenemanget, vänligen avboka ditt deltagande på
       evenemangssidan. Från och med augusti 2025 måste du avboka senast 48
       timmar före evenemanget.<br />
-      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+      <a href="{{ occurrence_url }}">Avboka registrering</a>.
     </p>
 
     <address>

--- a/notification_importers/templates/email/occurrence_enrolment-sv.html
+++ b/notification_importers/templates/email/occurrence_enrolment-sv.html
@@ -1,12 +1,38 @@
-Tack för din anmälan till {{ event.name }}, {{ localtime(occurrence.time).strftime('%d.%m.%Y på %H.%M') }}. Lokalen är {{ occurrence.venue.name }}, {{ occurrence.venue.address }}, välkomna! Du hittar uppgifterna om ditt evenemang genom att logga in på tjänsten Kulturens fadderbarn.
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <title>Bekräftelse för din anmälan till {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      Tack för din anmälan till {{ event.name }}, {{
+      localtime(occurrence.time).strftime('%d.%m.%Y på %H.%M') }}. Lokalen är {{
+      occurrence.venue.name }}, {{ occurrence.venue.address }}, välkomna! Du
+      hittar uppgifterna om ditt evenemang genom att logga in på tjänsten
+      Kulturens fadderbarn.
+    </p>
 
-Biljett till evenemanget
-Bifogat till detta meddelande finns en QR-kod som är biljetten till evenemanget. Ta med dig QR-koden och visa upp den när du kommer till evenemanget.
+    <h2>Biljett till evenemanget</h2>
+    <p>
+      Bifogat till detta meddelande finns en QR-kod som är biljetten till
+      evenemanget. Ta med dig QR-koden och visa upp den när du kommer till
+      evenemanget.
+    </p>
 
-Avbokning av deltagande
-Om du inte kan delta i evenemanget, vänligen avboka ditt deltagande på evenemangssidan. Från och med augusti 2025 måste du avboka senast 48 timmar före evenemanget.
-{{ occurrence_url }}
+    <h2>Avbokning av deltagande</h2>
+    <p>
+      Om du inte kan delta i evenemanget, vänligen avboka ditt deltagande på
+      evenemangssidan. Från och med augusti 2025 måste du avboka senast 48
+      timmar före evenemanget.<br />
+      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+    </p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_feedback-en.html
+++ b/notification_importers/templates/email/occurrence_feedback-en.html
@@ -1,5 +1,20 @@
-You just attended a Culture Kids event.
-
-We collect feedback from attendees because we want to make our events even better.
-
-The feedback survey is available at: https://forms.office.com/r/FKRTi1QxmJ
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Feedback survey, Culture Kids</title>
+  </head>
+  <body>
+    <p>You just attended a Culture Kids event.</p>
+    <p>
+      We collect feedback from attendees because we want to make our events even
+      better.
+    </p>
+    <p>
+      The feedback survey is available at:
+      <a href="https://forms.office.com/r/FKRTi1QxmJ"
+        >https://forms.office.com/r/FKRTi1QxmJ</a
+      >
+    </p>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_feedback-en.html
+++ b/notification_importers/templates/email/occurrence_feedback-en.html
@@ -1,0 +1,5 @@
+You just attended a Culture Kids event.
+
+We collect feedback from attendees because we want to make our events even better.
+
+The feedback survey is available at: https://forms.office.com/r/FKRTi1QxmJ

--- a/notification_importers/templates/email/occurrence_feedback-fi.html
+++ b/notification_importers/templates/email/occurrence_feedback-fi.html
@@ -1,0 +1,7 @@
+Osallistuit juuri Kulttuurin kummilasten tapahtumaan.
+
+Keräämme osallistujilta palautetta, koska haluamme tehdä tapahtumista yhä parempia.
+
+Palautekysely löytyy osoitteesta:  https://forms.office.com/r/FKRTi1QxmJ
+
+Kyselyyn vastataan nimettomästi.

--- a/notification_importers/templates/email/occurrence_feedback-fi.html
+++ b/notification_importers/templates/email/occurrence_feedback-fi.html
@@ -1,7 +1,21 @@
-Osallistuit juuri Kulttuurin kummilasten tapahtumaan.
-
-Keräämme osallistujilta palautetta, koska haluamme tehdä tapahtumista yhä parempia.
-
-Palautekysely löytyy osoitteesta:  https://forms.office.com/r/FKRTi1QxmJ
-
-Kyselyyn vastataan nimettomästi.
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Palautekysely, Kulttuurin kummilapset</title>
+  </head>
+  <body>
+    <p>Osallistuit juuri Kulttuurin kummilasten tapahtumaan.</p>
+    <p>
+      Keräämme osallistujilta palautetta, koska haluamme tehdä tapahtumista yhä
+      parempia.
+    </p>
+    <p>
+      Palautekysely löytyy osoitteesta:
+      <a href="https://forms.office.com/r/FKRTi1QxmJ"
+        >https://forms.office.com/r/FKRTi1QxmJ</a
+      >
+    </p>
+    <p>Kyselyyn vastataan nimettömästi.</p>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_feedback-sv.html
+++ b/notification_importers/templates/email/occurrence_feedback-sv.html
@@ -1,0 +1,5 @@
+Du deltog nyligen i evenemanget Kulturens fadderbarn.
+
+Din respons är viktig för oss eftersom vi vill göra våra evenemang ännu bättre.
+
+Vi är tacksamma om du kan svara på en anonym responsenkät på adressen: https://forms.office.com/r/FKRTi1QxmJ

--- a/notification_importers/templates/email/occurrence_feedback-sv.html
+++ b/notification_importers/templates/email/occurrence_feedback-sv.html
@@ -1,5 +1,20 @@
-Du deltog nyligen i evenemanget Kulturens fadderbarn.
-
-Din respons är viktig för oss eftersom vi vill göra våra evenemang ännu bättre.
-
-Vi är tacksamma om du kan svara på en anonym responsenkät på adressen: https://forms.office.com/r/FKRTi1QxmJ
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <title>Responsformulär, Kulturens fadderbarn</title>
+  </head>
+  <body>
+    <p>Du deltog nyligen i evenemanget Kulturens fadderbarn.</p>
+    <p>
+      Din respons är viktig för oss eftersom vi vill göra våra evenemang ännu
+      bättre.
+    </p>
+    <p>
+      Vi är tacksamma om du kan svara på en anonym responsenkät på adressen:
+      <a href="https://forms.office.com/r/FKRTi1QxmJ"
+        >https://forms.office.com/r/FKRTi1QxmJ</a
+      >
+    </p>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_reminder-en.html
+++ b/notification_importers/templates/email/occurrence_reminder-en.html
@@ -1,14 +1,38 @@
-You have signed up for {{ event.name }}, {{ localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }}. The venue is {{ occurrence.venue.name }} at {{ occurrence.venue.address }}, we are looking forward to seeing you there!
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Reminder: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      You have signed up for {{ event.name }}, {{
+      localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }}. The venue is
+      {{ occurrence.venue.name }} at {{ occurrence.venue.address }}, we are
+      looking forward to seeing you there!
+    </p>
 
-Admission ticket
-Attached to this message is a QR code which is the ticket for the event. Take the QR code with you and show it when you arrive at the event.
+    <h2>Admission ticket</h2>
+    <p>
+      Attached to this message is a QR code which is the ticket for the event.
+      Take the QR code with you and show it when you arrive at the event.
+    </p>
 
-Cancellation of participation
-If you are unable to attend the event, please cancel your participation on the event page. From August 2025, you must cancel at least 48 hours before the event.
-{{ occurrence_url }}
+    <h2>Cancellation of participation</h2>
+    <p>
+      If you are unable to attend the event, please cancel your participation on
+      the event page. From August 2025, you must cancel at least 48 hours before
+      the event.<br />
+      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+    </p>
 
-See you soon!
+    <p>See you soon!</p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_reminder-en.html
+++ b/notification_importers/templates/email/occurrence_reminder-en.html
@@ -23,7 +23,7 @@
       If you are unable to attend the event, please cancel your participation on
       the event page. From August 2025, you must cancel at least 48 hours before
       the event.<br />
-      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+      <a href="{{ occurrence_url }}">Cancel enrolment</a>.
     </p>
 
     <p>See you soon!</p>

--- a/notification_importers/templates/email/occurrence_reminder-en.html
+++ b/notification_importers/templates/email/occurrence_reminder-en.html
@@ -1,0 +1,14 @@
+You have signed up for {{ event.name }}, {{ localtime(occurrence.time).strftime('%d.%m.%Y at %H.%M') }}. The venue is {{ occurrence.venue.name }} at {{ occurrence.venue.address }}, we are looking forward to seeing you there!
+
+Admission ticket
+Attached to this message is a QR code which is the ticket for the event. Take the QR code with you and show it when you arrive at the event.
+
+Cancellation of participation
+If you are unable to attend the event, please cancel your participation on the event page. From August 2025, you must cancel at least 48 hours before the event.
+{{ occurrence_url }}
+
+See you soon!
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_reminder-fi.html
+++ b/notification_importers/templates/email/occurrence_reminder-fi.html
@@ -1,0 +1,14 @@
+Olette ilmoittautuneet {{ localtime(occurrence.time).strftime('%d.%m.%Y klo %H.%M') }} järjestettävään tapahtumaan {{ event.name }}. Tapahtuman paikka on {{ occurrence.venue.name }}, {{ occurrence.venue.address }}, tervetuloa!
+
+Pääsylippu
+Tämän viestin liitteenä on QR-koodi, joka on tapahtuman pääsylippu. Ota QR-koodi mukaan ja näytä se, kun saavut tapahtumaan.
+
+Osallistumisen peruminen
+Jos ette pääse osallistumaan tapahtumaan, peru osallistumisenne tapahtuman sivulla. Elokuusta 2025 alkaen sinun tulee perua viimeistään 48 tuntia ennen tapahtumaa.
+{{ occurrence_url }}
+
+Pian tavataan!
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_reminder-fi.html
+++ b/notification_importers/templates/email/occurrence_reminder-fi.html
@@ -1,14 +1,38 @@
-Olette ilmoittautuneet {{ localtime(occurrence.time).strftime('%d.%m.%Y klo %H.%M') }} järjestettävään tapahtumaan {{ event.name }}. Tapahtuman paikka on {{ occurrence.venue.name }}, {{ occurrence.venue.address }}, tervetuloa!
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Muistutus: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      Olette ilmoittautuneet {{ localtime(occurrence.time).strftime('%d.%m.%Y
+      klo %H.%M') }} järjestettävään tapahtumaan {{ event.name }}. Tapahtuman
+      paikka on {{ occurrence.venue.name }}, {{ occurrence.venue.address }},
+      tervetuloa!
+    </p>
 
-Pääsylippu
-Tämän viestin liitteenä on QR-koodi, joka on tapahtuman pääsylippu. Ota QR-koodi mukaan ja näytä se, kun saavut tapahtumaan.
+    <h2>Pääsylippu</h2>
+    <p>
+      Tämän viestin liitteenä on QR-koodi, joka on tapahtuman pääsylippu. Ota
+      QR-koodi mukaan ja näytä se, kun saavut tapahtumaan.
+    </p>
 
-Osallistumisen peruminen
-Jos ette pääse osallistumaan tapahtumaan, peru osallistumisenne tapahtuman sivulla. Elokuusta 2025 alkaen sinun tulee perua viimeistään 48 tuntia ennen tapahtumaa.
-{{ occurrence_url }}
+    <h2>Osallistumisen peruminen</h2>
+    <p>
+      Jos ette pääse osallistumaan tapahtumaan, peru osallistumisenne tapahtuman
+      sivulla. Elokuusta 2025 alkaen sinun tulee perua viimeistään 48 tuntia
+      ennen tapahtumaa.<br />
+      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+    </p>
 
-Pian tavataan!
+    <p>Pian tavataan!</p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_reminder-fi.html
+++ b/notification_importers/templates/email/occurrence_reminder-fi.html
@@ -23,7 +23,7 @@
       Jos ette pääse osallistumaan tapahtumaan, peru osallistumisenne tapahtuman
       sivulla. Elokuusta 2025 alkaen sinun tulee perua viimeistään 48 tuntia
       ennen tapahtumaa.<br />
-      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+      <a href="{{ occurrence_url }}">Peruuta ilmoittautuminen</a>.
     </p>
 
     <p>Pian tavataan!</p>

--- a/notification_importers/templates/email/occurrence_reminder-sv.html
+++ b/notification_importers/templates/email/occurrence_reminder-sv.html
@@ -1,14 +1,39 @@
-Ni har anmält er till {{ event.name }} {{ localtime(occurrence.time).strftime('%d.%m.%Y på %H.%M') }}. Lokalen är {{ occurrence.venue.name }}, {{ occurrence.venue.address }}, välkomna!
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <title>Påminnelse: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      Du har anmält dig till {{ event.name }} {{
+      localtime(occurrence.time).strftime('%d.%m.%Y kl %H.%M') }}. Platsen är {{
+      occurrence.venue.name }}, {{ occurrence.venue.address }}. Vi ser fram emot
+      att träffa dig där!
+    </p>
 
-Biljett till evenemanget
-Bifogat till detta meddelande finns en QR-kod som är biljetten till evenemanget. Ta med dig QR-koden och visa upp den när du kommer till evenemanget.
+    <h2>Biljett till evenemanget</h2>
+    <p>
+      Bifogat till detta meddelande finns en QR-kod som är biljetten till
+      evenemanget. Ta med dig QR-koden och visa upp den när du kommer till
+      evenemanget.
+    </p>
 
- Avbokning av deltagande
-Om du inte kan delta i evenemanget, vänligen avboka ditt deltagande på evenemangssidan. Från och med augusti 2025 måste du avboka senast 48 timmar före evenemanget.
-{{ occurrence_url }}
+    <h2>Avbokning av deltagande</h2>
+    <p>
+      Om du inte kan delta i evenemanget, vänligen avboka ditt deltagande på
+      evenemangssidan. Från och med augusti 2025 måste du avboka senast 48
+      timmar före evenemanget.<br />
+      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+    </p>
 
-Vi ses snart!
+    <p>Vi ses snart!</p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_reminder-sv.html
+++ b/notification_importers/templates/email/occurrence_reminder-sv.html
@@ -24,7 +24,7 @@
       Om du inte kan delta i evenemanget, vänligen avboka ditt deltagande på
       evenemangssidan. Från och med augusti 2025 måste du avboka senast 48
       timmar före evenemanget.<br />
-      <a href="{{ occurrence_url }}">{{ occurrence_url }}</a>
+      <a href="{{ occurrence_url }}">Avbuka registrering</a>.
     </p>
 
     <p>Vi ses snart!</p>

--- a/notification_importers/templates/email/occurrence_reminder-sv.html
+++ b/notification_importers/templates/email/occurrence_reminder-sv.html
@@ -1,0 +1,14 @@
+Ni har anmält er till {{ event.name }} {{ localtime(occurrence.time).strftime('%d.%m.%Y på %H.%M') }}. Lokalen är {{ occurrence.venue.name }}, {{ occurrence.venue.address }}, välkomna!
+
+Biljett till evenemanget
+Bifogat till detta meddelande finns en QR-kod som är biljetten till evenemanget. Ta med dig QR-koden och visa upp den när du kommer till evenemanget.
+
+ Avbokning av deltagande
+Om du inte kan delta i evenemanget, vänligen avboka ditt deltagande på evenemangssidan. Från och med augusti 2025 måste du avboka senast 48 timmar före evenemanget.
+{{ occurrence_url }}
+
+Vi ses snart!
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_unenrolment-en.html
+++ b/notification_importers/templates/email/occurrence_unenrolment-en.html
@@ -1,0 +1,4 @@
+You have cancelled your participation in {{ event.name }}. We are looking forward to seeing you at Culture Kids future events!
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_unenrolment-en.html
+++ b/notification_importers/templates/email/occurrence_unenrolment-en.html
@@ -1,4 +1,20 @@
-You have cancelled your participation in {{ event.name }}. We are looking forward to seeing you at Culture Kids future events!
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Cancellation of your participation: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      You have cancelled your participation in {{ event.name }}. We are looking
+      forward to seeing you at Culture Kids future events!
+    </p>
 
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_unenrolment-fi.html
+++ b/notification_importers/templates/email/occurrence_unenrolment-fi.html
@@ -1,5 +1,20 @@
-Olet peruuttanut ilmoittautumisesi tapahtumaan {{ event.name }}. Tervetuloa mukaan seuraaviin Kulttuurin kummilapset -tapahtumiin!
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Ilmoittautumisen peruutus: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      Olet peruuttanut ilmoittautumisesi tapahtumaan {{ event.name }}.
+      Tervetuloa mukaan seuraaviin Kulttuurin kummilapset -tapahtumiin!
+    </p>
 
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/occurrence_unenrolment-fi.html
+++ b/notification_importers/templates/email/occurrence_unenrolment-fi.html
@@ -1,0 +1,5 @@
+Olet peruuttanut ilmoittautumisesi tapahtumaan {{ event.name }}. Tervetuloa mukaan seuraaviin Kulttuurin kummilapset -tapahtumiin!
+
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_unenrolment-sv.html
+++ b/notification_importers/templates/email/occurrence_unenrolment-sv.html
@@ -1,0 +1,4 @@
+Du har avbokat din registrering till {{ event.name }}. Varmt välkommen till de följande evenemangen för Kulturens fadderbarn!
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/occurrence_unenrolment-sv.html
+++ b/notification_importers/templates/email/occurrence_unenrolment-sv.html
@@ -1,4 +1,20 @@
-Du har avbokat din registrering till {{ event.name }}. Varmt välkommen till de följande evenemangen för Kulturens fadderbarn!
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <title>Avbokning av anmälan: {{ event.name }}</title>
+  </head>
+  <body>
+    <p>
+      Du har avbokat din registrering till {{ event.name }}. Varmt välkommen
+      till de följande evenemangen för Kulturens fadderbarn!
+    </p>
 
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/signup-en.html
+++ b/notification_importers/templates/email/signup-en.html
@@ -1,0 +1,21 @@
+Welcome!
+
+You have created a profile in the Culture Kids service. We will send event invitations to this e-mail address at least two times a year. You can use the service to sign up for your preferred events. You can also view the events on the Culture Kids website (https://kummilapset.hel.fi), once you login. The service and the events are free of charge.
+
+We hope that you will have pleasant experiences with culture and arts!
+
+Culture Kids
+
+Culture Kids is a programme that pairs children living in Helsinki with a sponsor from the world of arts and culture. All of the city’s little ones born in or after 2020 are invited to join.
+Every year, the sponsor will invite the child to at least two free-of-charge cultural events, promoting the child’s development and the family’s well-being. The sponsorship will continue until the child starts school. 
+Children born in 2020 are sponsored by the Helsinki Philharmonic Orchestra.
+2021 by Helsinki City Theatre, Finnish National Theatre, Svenska Teatern, Theatre ILMI Ö., Q-teatteri and Puppet Theatre Sampo.
+2022 by Cirko – Center for New Circus, Hotel and Restaurant Museum, Finnish Museum of Photography, Dance House Helsinki, Dance Theatre Hurjaruuth and Theatre Museum.
+2023 by Architecture and Design Museum Finland, Helsinki City Museum, National Museum of Finland, Association of Cultural Heritage Education in Finland and Helsinki University Museum Flame
+2024 by Helsinki City Library and Helsinki City Sports Services
+2025 by HAM Helsinki Art Museum, Amos Rex, The Finnish National Gallery’s Ateneum Art Museum, Museum of Contemporary Art Kiasma and Sinebrychoff Art Museum, Sointi Jazz Orchestra and UMO Helsinki Jazz Orchestra
+
+The Culture Kids programme is arranged by the City of Helsinki Culture and Leisure Division.
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/signup-en.html
+++ b/notification_importers/templates/email/signup-en.html
@@ -1,21 +1,52 @@
-Welcome!
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Welcome!</title>
+  </head>
+  <body>
+    <p>Welcome!</p>
 
-You have created a profile in the Culture Kids service. We will send event invitations to this e-mail address at least two times a year. You can use the service to sign up for your preferred events. You can also view the events on the Culture Kids website (https://kummilapset.hel.fi), once you login. The service and the events are free of charge.
+    <p>
+      You have created a profile in the Culture Kids service. We will send event
+      invitations to this e-mail address at least two times a year. You can use
+      the service to sign up for your preferred events. You can also view the
+      events on the Culture Kids website (<a href="https://kummilapset.hel.fi"
+        >https://kummilapset.hel.fi</a
+      >), once you login. The service and the events are free of charge.
+    </p>
 
-We hope that you will have pleasant experiences with culture and arts!
+    <p>
+      We hope that you will have pleasant experiences with culture and arts!
+    </p>
 
-Culture Kids
+    <h2>Culture Kids</h2>
+    <p>
+      Culture Kids is a programme that pairs children living in Helsinki with a
+      sponsor from the world of arts and culture. All of the city’s little ones
+      born in or after 2020 are invited to join. Every year, the sponsor will
+      invite the child to at least two free-of-charge cultural events, promoting
+      the child’s development and the family’s well-being. The sponsorship will
+      continue until the child starts school.
+        <ul>
+            <li>Children born in 2020 are sponsored by the Helsinki Philharmonic Orchestra. </li>
+            <li>2021 by Helsinki City Theatre, Finnish National Theatre, Svenska Teatern, Theatre ILMI Ö., Q-teatteri and Puppet Theatre Sampo.</li>
+            <li>2022 by Cirko – Center for New Circus, Hotel and Restaurant Museum, Finnish Museum of Photography, Dance House Helsinki, Dance Theatre Hurjaruuth and Theatre Museum. </li>
+            <li>2023 by Architecture and Design Museum Finland, Helsinki City Museum, National Museum of Finland, Association of Cultural Heritage Education in Finland and Helsinki University Museum Flame</li>
+            <li>2024 by Helsinki City Library and Helsinki City Sports Services</li>
+            <li>2025 by HAM Helsinki Art Museum, Amos Rex, The Finnish National Gallery’s Ateneum Art Museum, Museum of Contemporary Art Kiasma and Sinebrychoff Art Museum, Sointi Jazz Orchestra and UMO Helsinki Jazz Orchestra</li>
+        </ul>
+    </p>
 
-Culture Kids is a programme that pairs children living in Helsinki with a sponsor from the world of arts and culture. All of the city’s little ones born in or after 2020 are invited to join.
-Every year, the sponsor will invite the child to at least two free-of-charge cultural events, promoting the child’s development and the family’s well-being. The sponsorship will continue until the child starts school. 
-Children born in 2020 are sponsored by the Helsinki Philharmonic Orchestra.
-2021 by Helsinki City Theatre, Finnish National Theatre, Svenska Teatern, Theatre ILMI Ö., Q-teatteri and Puppet Theatre Sampo.
-2022 by Cirko – Center for New Circus, Hotel and Restaurant Museum, Finnish Museum of Photography, Dance House Helsinki, Dance Theatre Hurjaruuth and Theatre Museum.
-2023 by Architecture and Design Museum Finland, Helsinki City Museum, National Museum of Finland, Association of Cultural Heritage Education in Finland and Helsinki University Museum Flame
-2024 by Helsinki City Library and Helsinki City Sports Services
-2025 by HAM Helsinki Art Museum, Amos Rex, The Finnish National Gallery’s Ateneum Art Museum, Museum of Contemporary Art Kiasma and Sinebrychoff Art Museum, Sointi Jazz Orchestra and UMO Helsinki Jazz Orchestra
-
-The Culture Kids programme is arranged by the City of Helsinki Culture and Leisure Division.
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <p>
+      The Culture Kids service is administered by the City of Helsinki Culture
+      and Leisure Division.
+    </p>
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/signup-fi.html
+++ b/notification_importers/templates/email/signup-fi.html
@@ -1,0 +1,20 @@
+Tervetuloa!
+
+Olet luonut profiilin Kulttuurin kummilapset -palveluun. Saat tapahtumakutsut tähän sähköpostiin vähintään kaksi kertaa vuodessa ja palvelun kautta pääset ilmoittautumaan sinulle parhaiten sopiviin tapahtumiin. Tapahtumat löytyvät myös suoraan Kulttuurin kummilapset (https://kummilapset.hel.fi) -sivuilta, kun kirjaudut sisään.
+
+Toivotamme hyviä yhteisiä hetkiä kulttuurin ja taiteen parissa!
+
+Kulttuurin kummilapset
+
+Jokaisella vuonna 2020 tai sen jälkeen syntyvällä helsinkiläisellä lapsella on oma kulttuurikummi. Kulttuurikummi kutsuu lapsen joka vuosi vähintään kahteen tapahtumaan. Tapahtumat ovat maksuttomia ja ne tukevat lapsen kehitystä ja perheen hyvinvointia. Kummius jatkuu siihen saakka kunnes lapsi aloittaa koulun.
+Kummit lapsen syntymävuoden mukaan:
+2020 Helsingin kaupunginorkesteri
+2021 Helsingin Kaupunginteatteri, Suomen Kansallisteatteri, Svenska Teatern, Teatteri ILMI Ö., Q-teatteri ja Nukketeatteri Sampo
+2022 Cirko - Uuden sirkuksen keskus, Hotelli- ja ravintolamuseo, Suomen valokuvataiteen museo, Tanssin talo, Tanssiteatteri Hurjaruuth ja Teatterimuseo
+2023 Arkkitehtuuri- ja designmuseo, Helsingin kaupunginmuseo, Suomen kansallismuseo, Suomen kulttuuriperintökasvatuksen seura ja Tiedemuseo Liekki (ent. Helsingin yliopistomuseo)
+2024 Helsingin kirjastopalvelut ja Helsingin liikuntapalvelut
+2025 HAM Helsingin taidemuseo, Amos Rex, Kansallisgalleria: Ateneumin taidemuseo, Nykytaiteen museo Kiasma ja Sinebrychoffin taidemuseo sekä Sointi Jazz Orchestra ja UMO Helsinki Jazz Orchestra
+
+Kulttuurin kummilapset -palvelua hallinnoi Helsingin kulttuurin ja vapaa-ajan toimiala.
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi

--- a/notification_importers/templates/email/signup-fi.html
+++ b/notification_importers/templates/email/signup-fi.html
@@ -1,20 +1,47 @@
-Tervetuloa!
+<!DOCTYPE html>
+<html lang="fi">
+  <head>
+    <meta charset="utf-8" />
+    <title>Tervetuloa Kulttuurin kummilapsiin!</title>
+  </head>
+  <body>
+    <p>Tervetuloa!</p>
 
-Olet luonut profiilin Kulttuurin kummilapset -palveluun. Saat tapahtumakutsut tähän sähköpostiin vähintään kaksi kertaa vuodessa ja palvelun kautta pääset ilmoittautumaan sinulle parhaiten sopiviin tapahtumiin. Tapahtumat löytyvät myös suoraan Kulttuurin kummilapset (https://kummilapset.hel.fi) -sivuilta, kun kirjaudut sisään.
+    <p>
+      Olet luonut profiilin Kulttuurin kummilapset -palveluun. Saat
+      tapahtumakutsut tähän sähköpostiin vähintään kaksi kertaa vuodessa ja
+      palvelun kautta pääset ilmoittautumaan sinulle parhaiten sopiviin
+      tapahtumiin. Tapahtumat löytyvät myös suoraan Kulttuurin kummilapset (<a
+        href="https://kummilapset.hel.fi"
+        >https://kummilapset.hel.fi</a
+      >) -sivuilta, kun kirjaudut sisään.
+    </p>
 
-Toivotamme hyviä yhteisiä hetkiä kulttuurin ja taiteen parissa!
+    <p>Toivotamme hyviä yhteisiä hetkiä kulttuurin ja taiteen parissa!</p>
 
-Kulttuurin kummilapset
+    <h2>Kulttuurin kummilapset</h2>
+    <p>
+        Jokaisella vuonna 2020 tai sen jälkeen syntyvällä helsinkiläisellä lapsella on oma kulttuurikummi. Kulttuurikummi kutsuu lapsen joka vuosi vähintään kahteen tapahtumaan. Tapahtumat ovat maksuttomia ja ne tukevat lapsen kehitystä ja perheen hyvinvointia. Kummius jatkuu siihen saakka kunnes lapsi aloittaa koulun.
+        Kummit lapsen syntymävuoden mukaan:
+        <ul>
+            <li>2020 Helsingin kaupunginorkesteri</li>
+            <li>2021 Helsingin Kaupunginteatteri, Suomen Kansallisteatteri, Svenska Teatern, Teatteri ILMI Ö., Q-teatteri ja Nukketeatteri Sampo</li>
+            <li>2022 Cirko - Uuden sirkuksen keskus, Hotelli- ja ravintolamuseo, Suomen valokuvataiteen museo, Tanssin talo, Tanssiteatteri Hurjaruuth ja Teatterimuseo</li>
+            <li>2023 Arkkitehtuuri- ja designmuseo, Helsingin kaupunginmuseo, Suomen kansallismuseo, Suomen kulttuuriperintökasvatuksen seura ja Tiedemuseo Liekki (ent. Helsingin yliopistomuseo)   </li>
+            <li>2024 Helsingin kirjastopalvelut ja Helsingin liikuntapalvelut</li>
+            <li>2025 HAM Helsingin taidemuseo, Amos Rex, Kansallisgalleria: Ateneumin taidemuseo, Nykytaiteen museo Kiasma ja Sinebrychoffin taidemuseo sekä Sointi Jazz Orchestra ja UMO Helsinki Jazz Orchestra</li>
+        </ul>
+    </p>
 
-Jokaisella vuonna 2020 tai sen jälkeen syntyvällä helsinkiläisellä lapsella on oma kulttuurikummi. Kulttuurikummi kutsuu lapsen joka vuosi vähintään kahteen tapahtumaan. Tapahtumat ovat maksuttomia ja ne tukevat lapsen kehitystä ja perheen hyvinvointia. Kummius jatkuu siihen saakka kunnes lapsi aloittaa koulun.
-Kummit lapsen syntymävuoden mukaan:
-2020 Helsingin kaupunginorkesteri
-2021 Helsingin Kaupunginteatteri, Suomen Kansallisteatteri, Svenska Teatern, Teatteri ILMI Ö., Q-teatteri ja Nukketeatteri Sampo
-2022 Cirko - Uuden sirkuksen keskus, Hotelli- ja ravintolamuseo, Suomen valokuvataiteen museo, Tanssin talo, Tanssiteatteri Hurjaruuth ja Teatterimuseo
-2023 Arkkitehtuuri- ja designmuseo, Helsingin kaupunginmuseo, Suomen kansallismuseo, Suomen kulttuuriperintökasvatuksen seura ja Tiedemuseo Liekki (ent. Helsingin yliopistomuseo)
-2024 Helsingin kirjastopalvelut ja Helsingin liikuntapalvelut
-2025 HAM Helsingin taidemuseo, Amos Rex, Kansallisgalleria: Ateneumin taidemuseo, Nykytaiteen museo Kiasma ja Sinebrychoffin taidemuseo sekä Sointi Jazz Orchestra ja UMO Helsinki Jazz Orchestra
-
-Kulttuurin kummilapset -palvelua hallinnoi Helsingin kulttuurin ja vapaa-ajan toimiala.
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <p>
+      Kulttuurin kummilapset -palvelua hallinnoi Helsingin kulttuurin ja
+      vapaa-ajan toimiala.
+    </p>
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi"
+        >kulttuurin.kummilapset@hel.fi</a
+      >
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/signup-sv.html
+++ b/notification_importers/templates/email/signup-sv.html
@@ -1,20 +1,36 @@
-Välkommen!
+<!DOCTYPE html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <title>Välkommen till Kulturens fadderbarn!</title>
+  </head>
+  <body>
+    <p>Välkommen!</p>
 
-Du har skapat en profil i tjänsten Kulturens fadderbarn. Du får inbjudningar per e-post minst två gånger om året till denna e-post och kan i tjänsten anmäla dig till de evenemang som bäst passar dig. Evenemangen visas också direkt på webbplatsen för Kulturens fadderbarn (https://kummilapset.hel.fi) när du loggar in. Tjänsten och evenemangen är helt avgiftsfria.
+    <p>
+      Du har skapat en profil i tjänsten Kulturens fadderbarn. Du får inbjudningar per e-post minst två gånger om året till denna e-post och kan i tjänsten anmäla dig till de evenemang som bäst passar dig. Evenemangen visas också direkt på webbplatsen för Kulturens fadderbarn (<a href="https://kummilapset.hel.fi">https://kummilapset.hel.fi</a>) när du loggar in. Tjänsten och evenemangen är helt avgiftsfria. 
+    </p>
 
-Vi önskar er trevliga gemensamma stunder med kultur och konst!
+    <p>Vi önskar er trevliga gemensamma stunder med kultur och konst!</p>
 
-Kulturens fadderbarn
+    <h2>Kulturens fadderbarn</h2>
+    <p>
+        Alla barn i Helsingfors som är födda 2020 och därefter har en egen kulturfadder. Kulturfaddern bjuder in barnet till minst två evenemang per år. Evenemangen är avgiftsfria samt stödjer barnets utveckling och familjens välbefinnande. Fadderskapet fortsätter tills barnet börjar skolan.<br>
+        <ul>
+            <li>Fadder till barn födda: 2020 Helsingfors stadsorkester</li>
+            <li>2021 Helsingfors Stadsteater, Finlands Nationalteater, Svenska Teatern, Teatteri ILMI Ö., Q-teatteri och Dockteatern Sampo</li>
+            <li>2022  Cirko - centrumet för nycirkus, Hotell- och restaurangmuseet, Dansens hus Helsingfors, Finlands fotografiska museum, Dansteatern Hurjaruuth och Teatermuseet.</li>
+            <li>Kulturens fadderbarn förvaltas av Kultur- och fritidssektorn i Helsingfors stad.</li>
+            <li>2023 Arkitektur- och designmuseet, Helsingfors stadsmuseum, Finlands Nationalmuseum,</li>
+            <li>Föreningen för kulturarvsfostran i Finland och Vetenskapsmuseet Lågan (tidigare Helsingfors universitetsmuseum)</li>
+            <li>2024 Helsingfors biblioteks– och idrottstjänster</li>
+            <li>2025 HAM Helsingfors konstmuseum, Amos Rex, Nationalgalleriet dvs. Konstmuseet Ateneum, Museet för nutidskonst Kiasma och Konstmuseet Sinebrychoff, Sointi Jazz Orchestra och UMO Helsinki Jazz Orchestra</li>
+        </ul>
+    </p>
 
-Alla barn i Helsingfors som är födda 2020 och därefter har en egen kulturfadder. Kulturfaddern bjuder in barnet till minst två evenemang per år. Evenemangen är avgiftsfria samt stödjer barnets utveckling och familjens välbefinnande. Fadderskapet fortsätter tills barnet börjar skolan.
-Fadder till barn födda: 2020 Helsingfors stadsorkester
-2021 Helsingfors Stadsteater, Finlands Nationalteater, Svenska Teatern, Teatteri ILMI Ö., Q-teatteri och Dockteatern Sampo
-2022  Cirko - centrumet för nycirkus, Hotell- och restaurangmuseet, Dansens hus Helsingfors, Finlands fotografiska museum, Dansteatern Hurjaruuth och Teatermuseet.
-Kulturens fadderbarn förvaltas av Kultur- och fritidssektorn i Helsingfors stad.
-2023 Arkitektur- och designmuseet, Helsingfors stadsmuseum, Finlands Nationalmuseum,
-Föreningen för kulturarvsfostran i Finland och Vetenskapsmuseet Lågan (tidigare Helsingfors universitetsmuseum)
-2024 Helsingfors biblioteks– och idrottstjänster
-2025 HAM Helsingfors konstmuseum, Amos Rex, Nationalgalleriet dvs. Konstmuseet Ateneum, Museet för nutidskonst Kiasma och Konstmuseet Sinebrychoff, Sointi Jazz Orchestra och UMO Helsinki Jazz Orchestra
-
-https://kummilapset.hel.fi
-kulttuurin.kummilapset@hel.fi
+    <address>
+      <a href="https://kummilapset.hel.fi">kummilapset.hel.fi</a><br />
+      <a href="mailto:kulttuurin.kummilapset@hel.fi">kulttuurin.kummilapset@hel.fi</a>
+    </address>
+  </body>
+</html>

--- a/notification_importers/templates/email/signup-sv.html
+++ b/notification_importers/templates/email/signup-sv.html
@@ -1,0 +1,20 @@
+Välkommen!
+
+Du har skapat en profil i tjänsten Kulturens fadderbarn. Du får inbjudningar per e-post minst två gånger om året till denna e-post och kan i tjänsten anmäla dig till de evenemang som bäst passar dig. Evenemangen visas också direkt på webbplatsen för Kulturens fadderbarn (https://kummilapset.hel.fi) när du loggar in. Tjänsten och evenemangen är helt avgiftsfria.
+
+Vi önskar er trevliga gemensamma stunder med kultur och konst!
+
+Kulturens fadderbarn
+
+Alla barn i Helsingfors som är födda 2020 och därefter har en egen kulturfadder. Kulturfaddern bjuder in barnet till minst två evenemang per år. Evenemangen är avgiftsfria samt stödjer barnets utveckling och familjens välbefinnande. Fadderskapet fortsätter tills barnet börjar skolan.
+Fadder till barn födda: 2020 Helsingfors stadsorkester
+2021 Helsingfors Stadsteater, Finlands Nationalteater, Svenska Teatern, Teatteri ILMI Ö., Q-teatteri och Dockteatern Sampo
+2022  Cirko - centrumet för nycirkus, Hotell- och restaurangmuseet, Dansens hus Helsingfors, Finlands fotografiska museum, Dansteatern Hurjaruuth och Teatermuseet.
+Kulturens fadderbarn förvaltas av Kultur- och fritidssektorn i Helsingfors stad.
+2023 Arkitektur- och designmuseet, Helsingfors stadsmuseum, Finlands Nationalmuseum,
+Föreningen för kulturarvsfostran i Finland och Vetenskapsmuseet Lågan (tidigare Helsingfors universitetsmuseum)
+2024 Helsingfors biblioteks– och idrottstjänster
+2025 HAM Helsingfors konstmuseum, Amos Rex, Nationalgalleriet dvs. Konstmuseet Ateneum, Museet för nutidskonst Kiasma och Konstmuseet Sinebrychoff, Sointi Jazz Orchestra och UMO Helsinki Jazz Orchestra
+
+https://kummilapset.hel.fi
+kulttuurin.kummilapset@hel.fi


### PR DESCRIPTION
KK-1441.

Based on https://github.com/City-of-Helsinki/kukkuu/pull/506, which starts using the `notification_importer` app (that was copied from [Kultus](https://github.com/City-of-Helsinki/palvelutarjotin/tree/d211e7fc841188194d2a03896c1f127b4720e28c/notification_importers)), but with a Google Spreadsheet importer.

In this PR, the notification templates content is copied from https://docs.google.com/spreadsheets/d/1TkdQsO50DHOg5pi1JhzudOL1GKpiK-V2DCIoAipKj-M. The content is then added to notification template HTML files that can be imported with `notification_importers.notification_importer.NotificationFileImporter`.

This changes the Google Spreadsheet importer to a file importer, so the notification templates can be fetched from the project's repository. The templates needs to be under `notification_importers` app in templates -folder. They should be categorized by the notification type, so the emai ltemplates should be under notification_importers/templates/email/ -folder. Then the files should be named so that the name is constracted from `[type]-[locale].html`.

The notification importer needs `<title>` -tag in order to set subject field properly. Also the HTML syntax makes the template look better when sent to customer. However, since there is no design for those templates yet, the HTML content should be as simple as possible (e.g. similar to markdown format). Target was to convert plain text messages to minimal HTML equivalent.

Instead of showing the long and ugly URL, now when we are using HTML-formatted notification templates, we could also use some text as a link instead of the URL (as text).

<img width="1758" alt="image" src="https://github.com/user-attachments/assets/1afc79a8-1ca3-4572-9838-e488c303ecd2" />
