### PR TITLE
KK-1453: uWSGI improvements

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -1,14 +1,62 @@
 [uwsgi]
+# https://uwsgi-docs.readthedocs.io/en/latest/Options.html
+strict = true  # Fail if any option is unknown
+
 http-socket = :8000
+http-timeout = 60
+
 chdir = /app
 module = kukkuu.wsgi
 static-map = /static=/var/static
 static-map = /media=/app/var/media
 uid = appuser
 gid = appuser
-master = 1
-processes = 2
-threads = 2
+
+# Settings required for uwsgitop
+stats = /tmp/statsock
+memory-report = true
+
+master = true
+# Enable threads for sentry, see:
+# https://docs.sentry.io/clients/python/advanced/#a-note-on-uwsgi
+enable-threads = true
+single-interpreter = true
+need-app = true
+processes = $(UWSGI_PROCESSES)
+threads = 1
+buffer-size = 65535 # Allow bigger requests that includes a big list of AD-groups. Default is 4096.
+
+# by default uwsgi reloads on SIGTERM instead of terminating
+# this makes container slow to stop, so we change it here
+die-on-term = true
+
+harakiri = 20
+harakiri-graceful-timeout = 5
+# Default listen queue is 100
+harakiri-queue-threshold = $(UWSGI_PROCESSES)
+
+# Reload workers regularly to keep memory fresh
+# and ease potential memory leaks
+max-requests = 1000         # Restart workers after this many requests
+max-worker-lifetime = 3600  # Restart workers after this many seconds
+reload-on-rss = 300         # Restart workers after this much resident memory
+worker-reload-mercy = 60    # How long to wait before forcefully killing workers (default is 60)
+
+# Suppress errors about clients closing sockets, happens with nginx as the ingress when
+# http pipes are closed before workers has had the time to serve content to the pipe
+ignore-sigpipe = true
+ignore-write-errors = true
+disable-write-exception = true
+
+if-env = SENTRY_DSN
+print = Enabled sentry logging for uWSGI
+plugin = sentry
+alarm = logsentry sentry:dsn=$(SENTRY_DSN),logger=uwsgi.sentry
+# Log full queue, segfault and harakiri errors to sentry
+alarm-backlog = logsentry
+alarm-segfault = logsentry
+alarm-log = logsentry HARAKIRI \[core.*\]
+endif =
+
 route = ^/readiness$ donotlog:
 route = ^/healthz$ donotlog:
-buffer-size = 65535 # Allow bigger requests that includes a big list of AD-groups. Default is 4096.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,5 +30,6 @@ if [[ -n "$*" ]]; then
 elif [[ "$DEV_SERVER" = "1" ]]; then
     python -Wd ./manage.py runserver 0.0.0.0:8081
 else
+    export UWSGI_PROCESSES=${UWSGI_PROCESSES:-4}
     uwsgi --ini .prod/uwsgi.ini
 fi

--- a/requirements-prod.in
+++ b/requirements-prod.in
@@ -1,1 +1,2 @@
 uwsgi
+uwsgitop

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -6,3 +6,5 @@
 #
 uwsgi==2.0.28
     # via -r requirements-prod.in
+uwsgitop==0.12
+    # via -r requirements-prod.in


### PR DESCRIPTION
Improve uWSGI options:
- Restart a worker after 1000 requests (max-requests)
- Restart a worker every hour (max-worker-lifetime)
- Restart a worker after 300MB resident memory usage (reload-on-rss)
- Restart a worker by force after 60 seconds (worker-reload-mercy)
- Use strict mode to catch unknown uWSGI options (strict)
- Require an application module to start (need-app)
- Avoid multiple interpreters (single-interpreter)
- Only use processes for concurrency, so only run one thread per
  process
- Suppress errors about clients closing sockets
- Add Harakiri options
- Add Sentry-setup
- Add uwsgitop and settings

Refs: KK-1453