### PR TITLE
KK-1462: Prevent SAS token from being exposed in client URLs

### DIFF
--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -226,9 +226,11 @@ if STORAGES_DEFAULT_BACKEND == "storages.backends.azure_storage.AzureStorage":
     AZURE_CONTAINER = env("AZURE_CONTAINER")
     AZURE_URL_EXPIRATION_SECS = env("AZURE_URL_EXPIRATION_SECS")
     if env("AZURE_BLOB_STORAGE_SAS_TOKEN"):
-        AZURE_SAS_TOKEN = env("AZURE_BLOB_STORAGE_SAS_TOKEN")
-        AZURE_ENDP = f"BlobEndpoint=https://{AZURE_ACCOUNT_NAME}.blob.core.windows.net"
-        AZURE_CONNECTION_STRING = f"{AZURE_ENDP};"
+        SAS_TOKEN = env("AZURE_BLOB_STORAGE_SAS_TOKEN")
+        AZURE_CUSTOM_DOMAIN = f"{AZURE_ACCOUNT_NAME}.blob.core.windows.net"
+        AZURE_ENDP = f"BlobEndpoint=https://{AZURE_CUSTOM_DOMAIN}"
+        AZURE_CONNECTION_STRING = f"{AZURE_ENDP};SharedAccessSignature={SAS_TOKEN};"
+        AZURE_QUERYSTRING_AUTH = False
     else:
         AZURE_ACCOUNT_KEY = env("AZURE_ACCOUNT_KEY")
 


### PR DESCRIPTION
Add `AZURE_QUERYSTRING_AUTH = False`. This setting prevents Django from appending SAS tokens to generated URLs.

When set to False, Django will generate URLs without authentication parameters.

Refs: KK-1462