### PR TITLE
feat: add password login allowlist

### DIFF
--- a/kukkuu/settings.py
+++ b/kukkuu/settings.py
@@ -98,6 +98,7 @@ env = environ.Env(
     GDPR_API_AUTHORIZATION_FIELD=(str, "authorization.permissions.scopes"),
     HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED=(bool, False),
     HELUSERS_PASSWORD_LOGIN_DISABLED=(bool, False),
+    HELUSERS_PASSWORD_LOGIN_ALLOWLIST=(list, []),
     TOKEN_AUTH_BROWSER_TEST_JWT_256BIT_SIGN_SECRET=(str, None),
     TOKEN_AUTH_BROWSER_TEST_JWT_ISSUER=(list, None),
     TOKEN_AUTH_BROWSER_TEST_ENABLED=(bool, False),
@@ -597,6 +598,7 @@ GDPR_API_DELETER = "gdpr.service.clear_data"
 
 HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED = env("HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED")
 HELUSERS_PASSWORD_LOGIN_DISABLED = env("HELUSERS_PASSWORD_LOGIN_DISABLED")
+HELUSERS_PASSWORD_LOGIN_ALLOWLIST = env("HELUSERS_PASSWORD_LOGIN_ALLOWLIST")
 
 # django-helusers stores access token expiration time as datetime
 # and needs a custom serializer to make it serializable to/from JSON:

--- a/requirements.txt
+++ b/requirements.txt
@@ -388,9 +388,9 @@ django-helsinki-health-endpoints==1.0.0 \
     --hash=sha256:75670113e99bfd1fc23e317a3a22cff563140f495655c2a5f6ab219389dafd52 \
     --hash=sha256:eebf1baa6917d7b0e11123aec191df773883102ec1653025a86d7037dba389e2
     # via -r requirements.in
-django-helusers==1.0.0 \
-    --hash=sha256:0e33e238347a4088927675574a7dad179ee1f9d9e958daecfa4862ad6f63f79c \
-    --hash=sha256:c18ff8ff0ff8fb72c2b802e005c680d4d477273b705a5c524aaff31c665d8e25
+django-helusers==1.1.0 \
+    --hash=sha256:5d6c4d0db11db633a031cfdcef6e754fb26c167d3e179d77882c2edecca60830 \
+    --hash=sha256:73ef1c9f3050cbb3a4f3a35264f26807f60a00b66eef31d8b07cd1ffd61de965
     # via
     #   -r requirements.in
     #   helsinki-profile-gdpr-api


### PR DESCRIPTION
Bump django-helusers to allow defined usernames to log in using the password login.

Refs: KK-1493