### PR TITLE
test: make browser tests more resilient

### DIFF
--- a/browser-tests/tests/pages/event.ts
+++ b/browser-tests/tests/pages/event.ts
@@ -26,7 +26,7 @@ export const eventAdd = {
   eventGroup: screen.getByLabelText("Event group:"),
 };
 
-export const route = () => `${envUrl()}/admin/events/event`;
+export const route = () => `${envUrl()}/admin/events/event/?all`;
 export const routeAdd = () => `${envUrl()}/admin/events/event/add`;
 
 // fill add form for new event

--- a/browser-tests/tests/pages/eventGroup.ts
+++ b/browser-tests/tests/pages/eventGroup.ts
@@ -23,7 +23,7 @@ export const eventGroupAdd = {
   project: screen.getByLabelText("Project:"),
 };
 
-export const route = () => `${envUrl()}/admin/events/eventgroup`;
+export const route = () => `${envUrl()}/admin/events/eventgroup/?all`;
 export const routeAdd = () => `${envUrl()}/admin/events/eventgroup/add`;
 
 // publish event group from the list view

--- a/browser-tests/tests/pages/message.ts
+++ b/browser-tests/tests/pages/message.ts
@@ -19,7 +19,7 @@ export const messageAdd = {
   event: screen.getByLabelText("Event:"),
 };
 
-export const route = () => `${envUrl()}/admin/messaging/message/`;
+export const route = () => `${envUrl()}/admin/messaging/message/?all`;
 export const routeAdd = () => `${envUrl()}/admin/messaging/message/add/`;
 
 // fill add form for new message

--- a/browser-tests/tests/pages/occurence.ts
+++ b/browser-tests/tests/pages/occurence.ts
@@ -20,7 +20,7 @@ export const occurenceAdd = {
   capacityOverride: screen.getByLabelText("Capacity override:"),
 };
 
-export const route = () => `${envUrl()}/admin/events/occurrence`;
+export const route = () => `${envUrl()}/admin/events/occurrence/?all`;
 export const routeAdd = () => `${envUrl()}/admin/events/occurrence/add`;
 
 export const fillFormAdd = async (

--- a/browser-tests/tests/pages/project.ts
+++ b/browser-tests/tests/pages/project.ts
@@ -17,7 +17,7 @@ export const projectAdd = {
   year: screen.getByLabelText("Year:"),
 };
 
-export const route = () => `${envUrl()}/admin/projects/project/`;
+export const route = () => `${envUrl()}/admin/projects/project/?all`;
 export const routeAdd = () => `${envUrl()}/admin/projects/project/add/`;
 
 export const addProject = async (t: TestController) => {

--- a/browser-tests/tests/pages/user.ts
+++ b/browser-tests/tests/pages/user.ts
@@ -32,7 +32,7 @@ export const userAdd = {
   chooseAllPermissions: Selector("#id_user_permissions_add_all"),
 };
 
-export const route = () => `${envUrl()}/admin/users/user/`;
+export const route = () => `${envUrl()}/admin/users/user/?all`;
 export const routeAdd = () => `${envUrl()}/admin/users/user/add/`;
 
 export const addUser = async (t: TestController) => {

--- a/browser-tests/tests/pages/venue.ts
+++ b/browser-tests/tests/pages/venue.ts
@@ -20,7 +20,7 @@ export const venueAdd = {
   description: screen.getByLabelText("Description:"),
 };
 
-export const route = () => `${envUrl()}/admin/venues/venue/`;
+export const route = () => `${envUrl()}/admin/venues/venue/?all`;
 export const routeAdd = () => `${envUrl()}/admin/venues/venue/add/`;
 
 export const addVenue = async (t: TestController) => {


### PR DESCRIPTION
Browser tests can currently fail if listings exceed pagination (100 items). Modify so that listings are get'ted with ?all which removes pagination.

Refs: KK-1531