### PR TITLE
test: use search to find events, event groups, messages and occurences

### DIFF
--- a/browser-tests/tests/pages/event.ts
+++ b/browser-tests/tests/pages/event.ts
@@ -26,7 +26,8 @@ export const eventAdd = {
   eventGroup: screen.getByLabelText("Event group:"),
 };
 
-export const route = () => `${envUrl()}/admin/events/event/?all`;
+export const route = (name: string) =>
+  `${envUrl()}/admin/events/event/?q=${encodeURIComponent(name)}`;
 export const routeAdd = () => `${envUrl()}/admin/events/event/add`;
 
 // fill add form for new event

--- a/browser-tests/tests/pages/eventGroup.ts
+++ b/browser-tests/tests/pages/eventGroup.ts
@@ -23,12 +23,13 @@ export const eventGroupAdd = {
   project: screen.getByLabelText("Project:"),
 };
 
-export const route = () => `${envUrl()}/admin/events/eventgroup/?all`;
+export const route = (name: string) =>
+  `${envUrl()}/admin/events/eventgroup/?q=${encodeURIComponent(name)}`;
 export const routeAdd = () => `${envUrl()}/admin/events/eventgroup/add`;
 
 // publish event group from the list view
 export const publish = async (t: TestController) => {
-  await t.navigateTo(route());
+  await t.navigateTo(route(eventGroup.name));
 
   // checkbox on event group row
   const selectCheckbox = Selector(".field-name_with_fallback")

--- a/browser-tests/tests/pages/message.ts
+++ b/browser-tests/tests/pages/message.ts
@@ -19,7 +19,8 @@ export const messageAdd = {
   event: screen.getByLabelText("Event:"),
 };
 
-export const route = () => `${envUrl()}/admin/messaging/message/?all`;
+export const route = (subject: string) =>
+  `${envUrl()}/admin/messaging/message/?q=${encodeURIComponent(subject)}`;
 export const routeAdd = () => `${envUrl()}/admin/messaging/message/add/`;
 
 // fill add form for new message

--- a/browser-tests/tests/pages/occurence.ts
+++ b/browser-tests/tests/pages/occurence.ts
@@ -20,7 +20,8 @@ export const occurenceAdd = {
   capacityOverride: screen.getByLabelText("Capacity override:"),
 };
 
-export const route = () => `${envUrl()}/admin/events/occurrence/?all`;
+export const route = (eventName: string) =>
+  `${envUrl()}/admin/events/occurrence/?q=${encodeURIComponent(eventName)}`;
 export const routeAdd = () => `${envUrl()}/admin/events/occurrence/add`;
 
 export const fillFormAdd = async (


### PR DESCRIPTION
Browser tests generate these on every test run, and all is not enough because it shows by default at most 250 results.

Refs: KK-1547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated browser test navigation to search for specific events, event groups, messages, and occurrences.
  * Added URL encoding for search terms to support names and subjects containing special characters.
  * Updated related test flows to use filtered search results instead of unfiltered lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->